### PR TITLE
fix(cli): correctly import json module

### DIFF
--- a/packages/cli/src/lib/cli.ts
+++ b/packages/cli/src/lib/cli.ts
@@ -1,6 +1,9 @@
 import { Command } from 'commander';
 import { getConfig } from '@callstack/rnef-config';
-import { version } from '../../package.json';
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+
+const {version} = require("./../../package.json");
 
 const program = new Command();
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

In ESM Node.js we cannot import `.json` files as in CJS, we need to either use `createRequire` helper function or use `fs` module to just read the file.

### Test plan

1. Crate a project with `create-app` command
2. Execute `node path/to/cli/packages/dist/src/bin.js`