### PR TITLE
fix: set cliFile in Gradle to point to RNEF instead of RNC CLI

### DIFF
--- a/packages/plugin-platform-android/src/template/android/app/build.gradle
+++ b/packages/plugin-platform-android/src/template/android/app/build.gradle
@@ -15,7 +15,7 @@ react {
     //   The folder where the react-native Codegen package is. Default is ../../node_modules/@react-native/codegen
     // codegenDir = file("../../node_modules/@react-native/codegen")
     //   The cli.js file which is the React Native CLI entrypoint. Default is ../../node_modules/react-native/cli.js
-    // cliFile = file("../../node_modules/react-native/cli.js")
+    cliFile = file("../../node_modules/@callstack/rnef-cli/src/bin.js")
 
     /* Variants */
     //   The list of variants to that are debuggable. For those we're going to


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Found this during testing #29 

### Test plan

`rnef run:android --mode release` to use `rnef bundle` instead of `react-native bundle`.
