### PR TITLE
fix: set missing `root` property to config

### DIFF
--- a/packages/config/src/lib/config.ts
+++ b/packages/config/src/lib/config.ts
@@ -47,12 +47,19 @@ const importUp = async <T>(dir: string, name: string): Promise<T> => {
   for (const ext of extensions) {
     const filePathWithExt = `${filePath}${ext}`;
     if (fs.existsSync(filePathWithExt)) {
+      let config: T;
+
       if (ext === '.mjs') {
-        return import(filePathWithExt).then((module) => module.default);
+        config = await import(filePathWithExt).then((module) => module.default);
       } else {
         const require = createRequire(import.meta.url);
-        return require(filePathWithExt);
+        config = require(filePathWithExt);
       }
+
+      return {
+        root: dir,
+        ...config,
+      };
     }
   }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

The goal of `importUp` is to find config in parent directories, it works fine but it didn't pass the directory when the config was found in different directory than `process.cwd()` e.g. when someone runs `rnef run:android` from `/android` folder.

Before:

![CleanShot 2024-12-02 at 13 20 44@2x](https://github.com/user-attachments/assets/8939c443-8657-4eae-be62-d82774b2c822)

After:

![CleanShot 2024-12-02 at 13 21 00@2x](https://github.com/user-attachments/assets/d9a93fff-1212-4e0c-9b80-e7a0b53a39b6)

### Test plan

1. Go to `/android`
2. `rnef run:android` should run correctly.
