### PR TITLE
fix(config): react-native treated as a dependency

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -11,6 +11,10 @@ function isValidRNDependency(config: DependencyConfig) {
 
 function filterConfig(config: Config) {
   const filtered = { ...config };
+  // `react-native` is not a dependency. When loading it through community CLI it's not an issue,
+  // but in our case we don't install `@react-native-community/cli-platform-*` as a dependencies
+  // so the config.platforms key is empty, which makes autolinking treat it as a dependency.
+  delete filtered.dependencies['react-native'];
   Object.keys(filtered.dependencies).forEach((item) => {
     if (!isValidRNDependency(filtered.dependencies[item])) {
       delete filtered.dependencies[item];


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes `rnef config` command that includes `react-native` as a dependency when `@react-native-community/cli-platform-ios` or `@react-native-community/cli-platform-android` are not installed in a project, which should usually be the case for RNEF projects. 

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
