### PR TITLE
feat: add helpers for getting RN path, version and platforms to simplify bundler plugin config

### DIFF
--- a/packages/plugin-metro/src/__tests__/pluginMetro.test.ts
+++ b/packages/plugin-metro/src/__tests__/pluginMetro.test.ts
@@ -1,17 +1,16 @@
 import { pluginMetro } from '../lib/pluginMetro.js';
 import { expect, test } from 'vitest';
 
-const pluginApi = { registerCommand: vi.fn() };
+const pluginApi = {
+  registerCommand: vi.fn(),
+  getProjectRoot: vi.fn(),
+  getReactNativePath: vi.fn(),
+  getReactNativeVersion: vi.fn(),
+  getPlatforms: vi.fn(),
+};
 
 test('plugin is called with correct arguments and returns its name and description', () => {
-  const plugin = pluginMetro({
-    root: '/',
-    reactNativeVersion: '0.77.0-rc.2',
-    reactNativePath: '/path/to/react-native',
-    platforms: {
-      android: {},
-    },
-  })(pluginApi);
+  const plugin = pluginMetro()(pluginApi);
 
   expect(plugin).toMatchObject({
     name: 'plugin-metro',

--- a/packages/plugin-metro/src/lib/pluginMetro.ts
+++ b/packages/plugin-metro/src/lib/pluginMetro.ts
@@ -7,13 +7,10 @@ import {
 import { logger } from '@callstack/rnef-tools';
 
 type PluginConfig = {
-  root?: string;
-  reactNativeVersion: string;
-  reactNativePath: string;
-  platforms: {
-    [platformName: string]: {
-      npmPackageName?: string;
-    };
+  reactNativeVersion?: string;
+  reactNativePath?: string;
+  platforms?: {
+    [platformName: string]: object;
   };
 };
 
@@ -60,7 +57,7 @@ type BundleCommandArgs = {
 };
 
 export const pluginMetro =
-  (pluginConfig: PluginConfig) =>
+  (pluginConfig: PluginConfig = {}) =>
   (api: PluginApi): PluginOutput => {
     api.registerCommand({
       name: 'start',
@@ -68,7 +65,20 @@ export const pluginMetro =
       // @ts-expect-error todo fix this
       action: (args: StartCommandArgs) => {
         const root = api.getProjectRoot();
-        startCommand.func(undefined, { root, ...pluginConfig }, args);
+        const reactNativeVersion = api.getReactNativeVersion();
+        const reactNativePath = api.getReactNativePath();
+        const platforms = api.getPlatforms();
+        startCommand.func(
+          undefined,
+          {
+            root,
+            reactNativeVersion,
+            reactNativePath,
+            platforms,
+            ...pluginConfig,
+          },
+          args
+        );
       },
       options: startCommand.options,
     });
@@ -86,7 +96,20 @@ export const pluginMetro =
           process.exit(1);
         }
         const root = api.getProjectRoot();
-        bundleCommand.func(undefined, { root, ...pluginConfig }, args);
+        const reactNativeVersion = api.getReactNativeVersion();
+        const reactNativePath = api.getReactNativePath();
+        const platforms = api.getPlatforms();
+        bundleCommand.func(
+          undefined,
+          {
+            root,
+            reactNativeVersion,
+            reactNativePath,
+            platforms,
+            ...pluginConfig,
+          },
+          args
+        );
       },
       options: bundleCommand.options,
     });

--- a/packages/plugin-repack/src/lib/pluginRepack.ts
+++ b/packages/plugin-repack/src/lib/pluginRepack.ts
@@ -3,12 +3,8 @@ import commands from '@callstack/repack/commands/rspack';
 import { logger } from '@callstack/rnef-tools';
 
 type PluginConfig = {
-  root?: string;
-  reactNativePath?: string;
-  platforms: {
-    [key: string]: {
-      npmPackageName?: string;
-    };
+  platforms?: {
+    [key: string]: object;
   };
 };
 
@@ -24,14 +20,19 @@ const bundleCommand = commands.find(
 );
 
 export const pluginRepack =
-  (pluginConfig: PluginConfig) =>
+  (pluginConfig: PluginConfig = {}) =>
   (api: PluginApi): PluginOutput => {
     api.registerCommand({
       name: 'start',
       description: 'Starts Re.Pack dev server.',
       action: (args) => {
         const root = api.getProjectRoot();
-        startCommand.func(undefined, { root, ...pluginConfig }, args);
+        const platforms = api.getPlatforms();
+        startCommand.func(
+          undefined,
+          { root, platforms, ...pluginConfig },
+          args
+        );
       },
       options: startCommand.options,
     });
@@ -48,7 +49,12 @@ export const pluginRepack =
           process.exit(1);
         }
         const root = api.getProjectRoot();
-        bundleCommand.func(undefined, { root, ...pluginConfig }, args);
+        const platforms = api.getPlatforms();
+        bundleCommand.func(
+          undefined,
+          { root, platforms, ...pluginConfig },
+          args
+        );
       },
       options: bundleCommand.options,
     });


### PR DESCRIPTION

### Summary

Added `reactNativePath`, `reactNativeVersion` to config.
Added `getReactNativePath`, `getReactNativeVersion` and `getPlatforms` to PluginApi so they're available for e.g. bundler plugins.

This makes configuring Metro and Re.Pack plugins as simple as calling them: `pluginMetro()` or `pluginRepack()`.

### Test plan

Updated tests to reflect public API.
