### PR TITLE
fix(template): include `npx` when executing `config` command

### DIFF
--- a/packages/plugin-platform-android/template/android/settings.gradle
+++ b/packages/plugin-platform-android/template/android/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
 plugins { id("com.facebook.react.settings") }
-extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand(['rnef', 'config', '-p', 'android']) }
+extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand(['npx', 'rnef', 'config', '-p', 'android']) }
 rootProject.name = 'HelloWorld'
 include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')

--- a/packages/plugin-platform-ios/template/ios/Podfile
+++ b/packages/plugin-platform-ios/template/ios/Podfile
@@ -15,7 +15,7 @@ if linkage != nil
 end
 
 target 'HelloWorld' do
-  config = use_native_modules!(['rnef', 'config', '-p', 'ios'])
+  config = use_native_modules!(['npx', 'rnef', 'config', '-p', 'ios'])
 
   use_react_native!(
     :path => config[:reactNativePath],


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

When running project in non-dev env (without having globally linked `rnef` package) we should be executing `rnef` with `npx` prefix.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
