### PR TITLE
refactor: use rnef build in actions

### DIFF
--- a/packages/plugin-platform-ios/template/.github/actions/rnef-remote-build-ios/action.yml
+++ b/packages/plugin-platform-ios/template/.github/actions/rnef-remote-build-ios/action.yml
@@ -56,25 +56,9 @@ runs:
 
     - name: Build iOS
       if: ${{ !steps.cached-url.outputs.artifact-url }}
-      # Taken from: https://github.com/microsoft/rnx-kit/blob/ac1cfa362ace6172a020d2b4bcdd63c398527c17/incubator/build/scripts/build-apple.sh#L49
-      # @TODO replace with RNEF CLI call.
       run: |
         cd ios
-        xcworkspace=$(find . -maxdepth 1 -name '*.xcworkspace' -type d | head -1)
-        xcodebuild \
-           -workspace "${xcworkspace}" \
-           -scheme "${{inputs.scheme}}" \
-           -destination "generic/platform=iOS Simulator" \
-           -configuration Debug \
-           -derivedDataPath DerivedData \
-           ARCHS="${{inputs.architectures}}" \
-           CODE_SIGNING_ALLOWED=NO \
-           CLANG_ADDRESS_SANITIZER=NO \
-           CLANG_UNDEFINED_BEHAVIOR_SANITIZER=NO \
-           OTHER_CFLAGS='$(inherited) -fno-sanitize=undefined -fno-sanitize=bounds -fstack-protector-strong' \
-           OTHER_LDFLAGS='$(inherited) -fno-sanitize=undefined -fno-sanitize=bounds -fstack-protector-strong' \
-           COMPILER_INDEX_STORE_ENABLE=NO \
-           build
+        pnpm rnef build:ios
       shell: bash
 
     - name: Prepare Artifact


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Update GH build actions with `rnef` packages. Currently untestable, because RNEF packages are not published, hence `npm install` in deployed repo (outside of monorepo) won't work.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
