### PR TITLE
refactor: infer platform sdk from platform name for installApp

### DIFF
--- a/packages/plugin-platform-apple/src/lib/commands/run/installApp.ts
+++ b/packages/plugin-platform-apple/src/lib/commands/run/installApp.ts
@@ -6,7 +6,6 @@ import { ApplePlatform, XcodeProjectInfo } from '../../types/index.js';
 import spawn, { SubprocessError } from 'nano-spawn';
 
 type Options = {
-  buildOutput: string;
   xcodeProject: XcodeProjectInfo;
   sourceDir: string;
   mode: string;
@@ -18,7 +17,6 @@ type Options = {
 };
 
 export default async function installApp({
-  buildOutput,
   xcodeProject,
   sourceDir,
   mode,
@@ -34,7 +32,7 @@ export default async function installApp({
     xcodeProject,
     sourceDir,
     mode,
-    buildOutput,
+    `export PLATFORM_NAME=${getPlatformSDK(platform)}`, // simulate build output
     scheme,
     target
   );
@@ -84,5 +82,18 @@ export default async function installApp({
       }`
     );
     throw error;
+  }
+}
+
+function getPlatformSDK(platform: ApplePlatform) {
+  switch (platform) {
+    case 'ios':
+      return 'iphonesimulator';
+    case 'macos':
+      return 'macosx';
+    case 'tvos':
+      return 'appletvsimulator';
+    case 'visionos':
+      return 'xrsimulator';
   }
 }

--- a/packages/plugin-platform-apple/src/lib/commands/run/runOnSimulator.ts
+++ b/packages/plugin-platform-apple/src/lib/commands/run/runOnSimulator.ts
@@ -43,9 +43,8 @@ export async function runOnSimulator(
   }
   loader.stop(`Launched Simulator "${simulator.name}".`);
 
-  let buildOutput;
   if (!binaryPath) {
-    buildOutput = await buildProject(
+    await buildProject(
       xcodeProject,
       sourceDir,
       platform,
@@ -58,7 +57,6 @@ export async function runOnSimulator(
 
   loader.start(`Installing the app on "${simulator.name}"`);
   await installApp({
-    buildOutput: buildOutput ?? '',
     xcodeProject,
     sourceDir,
     mode,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes a case where buildOutput is expected to be called when `--binary-path` flag is set, which is unnecessary.

### Test plan

Tested on `run:ios` and `run:visionos` (at #42) correctly installing the app on respective simulators.
