### PR TITLE
fix(build-ios): forward `stdout` & `stderr` logs in `--verbose` mode

### DIFF
--- a/packages/plugin-platform-apple/src/lib/commands/build/buildProject.ts
+++ b/packages/plugin-platform-apple/src/lib/commands/build/buildProject.ts
@@ -69,7 +69,7 @@ export const buildProject = async (
   try {
     const { output } = await spawn('xcodebuild', xcodebuildArgs, {
       cwd: sourceDir,
-      stdio: logger.isVerbose() ? 'inherit' : ['ignore', 'pipe', 'inherit'],
+      stdio: logger.isVerbose() ? 'inherit' : ['ignore', 'pipe', 'pipe'],
     });
     loader.stop(
       `Built the app with xcodebuild for ${scheme} scheme in ${mode} mode.`


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes #68 

### Test plan

Logs should be visible when `--verbose` option was passed