### PR TITLE
fix: running in projects without git remote set

### DIFF
--- a/packages/plugin-platform-apple/src/lib/utils/getInfo.ts
+++ b/packages/plugin-platform-apple/src/lib/utils/getInfo.ts
@@ -6,15 +6,6 @@ import { Info, XcodeProjectInfo } from '../types/index.js';
 import { logger, RnefError } from '@rnef/tools';
 import { spinner } from '@clack/prompts';
 
-function isErrorLike(err: unknown): err is { message: string } {
-  return Boolean(
-    err &&
-      typeof err === 'object' &&
-      'message' in err &&
-      typeof err.message === 'string'
-  );
-}
-
 function parseTargetList(json: string): Info | undefined {
   try {
     const info = JSON.parse(json);

--- a/packages/tools/src/lib/build-cache/github/artifacts.ts
+++ b/packages/tools/src/lib/build-cache/github/artifacts.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import { Octokit } from 'octokit';
 import AdmZip from 'adm-zip';
 import { detectGitHubRepoDetails } from './config.js';
+import logger from '../../logger.js';
 
 const PAGE_SIZE = 100; // Maximum allowed by GitHub API
 const GITHUB_TOKEN = process.env['GITHUB_TOKEN'];
@@ -16,14 +17,17 @@ export type GitHubArtifact = {
 
 export async function fetchGitHubArtifactsByName(
   name: string
-): Promise<GitHubArtifact[]> {
+): Promise<GitHubArtifact[] | []> {
   const octokit = new Octokit({
     auth: GITHUB_TOKEN,
   });
 
   const repoDetails = await detectGitHubRepoDetails();
   if (!repoDetails) {
-    throw new Error('Unable to detect GitHub repository details');
+    logger.warn(
+      'Unable to detect GitHub repository details. Proceeding with building locally using Gradle.'
+    );
+    return [];
   }
 
   const result: GitHubArtifact[] = [];

--- a/packages/tools/src/lib/build-cache/github/config.ts
+++ b/packages/tools/src/lib/build-cache/github/config.ts
@@ -31,7 +31,7 @@ export async function detectGitHubRepoDetails(): Promise<GitHubRepoDetails | nul
       repository: match[2],
     };
   } catch (error: unknown) {
-    logger.error('Unable to detect GitHub repository details:', error);
+    logger.debug('Unable to detect GitHub repository details:', error);
     return null;
   }
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

It should be possible to run RNEF in projects that are only local, not yet pushed to some remote.

Before:
<img width="795" alt="image" src="https://github.com/user-attachments/assets/3d00742c-f9c8-4eba-9e30-66eddbb21af6" />

After:
<img width="677" alt="image" src="https://github.com/user-attachments/assets/546371cb-0068-4142-bdb2-8210ef54cb2b" />

@mdjastrzebski am I using logger.warn wrong? Hoped the output will be like here: #72 

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
