### PR TITLE
refactor: remove clean-dist script

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -21,6 +21,7 @@
         "tsConfig": "{projectRoot}/tsconfig.lib.json",
         "buildableProjectDepsInPackageJsonType": "dependencies",
         "generateExportsField": true,
+        "generatePackageJson": false,
         "compilerOptions": {
           "module": "NodeNext",
           "outDir": "packages/{projectRoot}/dist"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "scripts": {
     "build": "nx run-many --target build",
-    "postbuild": "nx run-many --target clean-dist",
     "test": "nx run-many --target test",
     "e2e": "nx run-many --target e2e",
     "lint": "nx run-many --target lint",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,6 @@
     "rnef": "./dist/src/bin.js"
   },
   "scripts": {
-    "clean-dist": "rm -f dist/package.json",
     "publish:npm": "npm publish --access restricted",
     "publish:verdaccio": "npm publish --registry http://localhost:4873 --userconfig ../../.npmrc"
   },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -7,7 +7,6 @@
     "import": "./dist/src/index.js"
   },
   "scripts": {
-    "clean-dist": "rm -f dist/package.json",
     "publish:npm": "npm publish --access restricted",
     "publish:verdaccio": "npm publish --registry http://localhost:4873 --userconfig ../../.npmrc"
   },

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -10,7 +10,6 @@
     "dist"
   ],
   "scripts": {
-    "clean-dist": "rm -f dist/package.json",
     "publish:npm": "npm publish --access restricted",
     "publish:verdaccio": "npm publish --registry http://localhost:4873 --userconfig ../../.npmrc",
     "e2e": "vitest --config vite.e2e.config.js"

--- a/packages/plugin-metro/package.json
+++ b/packages/plugin-metro/package.json
@@ -12,7 +12,6 @@
     "template"
   ],
   "scripts": {
-    "clean-dist": "rm -f dist/package.json",
     "publish:npm": "npm publish --access restricted",
     "publish:verdaccio": "npm publish --registry http://localhost:4873 --userconfig ../../.npmrc"
   },

--- a/packages/plugin-platform-android/package.json
+++ b/packages/plugin-platform-android/package.json
@@ -13,7 +13,6 @@
     "react-native.config.ts"
   ],
   "scripts": {
-    "clean-dist": "rm -f dist/package.json",
     "publish:npm": "npm publish --access restricted",
     "publish:verdaccio": "npm publish --registry http://localhost:4873 --userconfig ../../.npmrc"
   },

--- a/packages/plugin-platform-apple/package.json
+++ b/packages/plugin-platform-apple/package.json
@@ -11,7 +11,6 @@
     "src"
   ],
   "scripts": {
-    "clean-dist": "rm -f dist/package.json",
     "publish:npm": "npm publish --access restricted",
     "publish:verdaccio": "npm publish --registry http://localhost:4873 --userconfig ../../.npmrc"
   },

--- a/packages/plugin-platform-ios/package.json
+++ b/packages/plugin-platform-ios/package.json
@@ -13,7 +13,6 @@
     "react-native.config.ts"
   ],
   "scripts": {
-    "clean-dist": "rm -f dist/package.json",
     "publish:npm": "npm publish --access restricted",
     "publish:verdaccio": "npm publish --registry http://localhost:4873 --userconfig ../../.npmrc"
   },

--- a/packages/plugin-repack/package.json
+++ b/packages/plugin-repack/package.json
@@ -12,7 +12,6 @@
     "template"
   ],
   "scripts": {
-    "clean-dist": "rm -f dist/package.json",
     "publish:npm": "npm publish --access restricted",
     "publish:verdaccio": "npm publish --registry http://localhost:4873 --userconfig ../../.npmrc"
   },

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -7,7 +7,6 @@
     "import": "./dist/src/index.js"
   },
   "scripts": {
-    "clean-dist": "rm -f dist/package.json",
     "publish:npm": "npm publish --access restricted",
     "publish:verdaccio": "npm publish --registry http://localhost:4873 --userconfig ../../.npmrc"
   },


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

We used custom `clean-dist` script in every package to remove `package.json` generated in `dist` folder. There is an Nx option controlling that behavior, so we can remove the script.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
