### PR TITLE
fix: nx build caching

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -7,8 +7,7 @@
   "extends": "nx/presets/npm.json",
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "namedInputs": {
-    "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"],
-    "default": ["sharedGlobals"]
+    "default": ["{projectRoot}/**/*"]
   },
   "targetDefaults": {
     "@nx/js:tsc": {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fix recently discovered issue when chaning TS files would not cause cache invalidation. Seems like this should have been broken from the begging, but perhaps some `@nx/js:tsc` behaviour change underneath.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Change *.ts files and run `pn build` to see if build is triggered or cached.
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
