### PR TITLE
fix(init): use relative path in bye message

### DIFF
--- a/packages/create-app/src/lib/utils/prompts.ts
+++ b/packages/create-app/src/lib/utils/prompts.ts
@@ -1,5 +1,6 @@
 import { intro, multiselect, note, outro, select, text } from '@clack/prompts';
 import { checkCancelPrompt, RnefError } from '@rnef/tools';
+import path from 'path';
 import type { TemplateInfo } from '../templates.js';
 import { validateProjectName } from '../validate-project-name.js';
 import { parsePackageManagerFromUserAgent } from './parsers.js';
@@ -45,8 +46,10 @@ export function printByeMessage(targetDir: string) {
 
   const pkgManagerCommand = pkgManager?.name ?? 'npm';
 
+  const relativeDir = path.relative(process.cwd(), targetDir);
+
   const nextSteps = [
-    `cd ${targetDir}`,
+    `cd ${relativeDir}`,
     `${pkgManagerCommand} install`,
     `${pkgManagerCommand} run start`,
   ].join('\n');


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Small dx improvement, `targetDir` can be get really long, in most cases it will be `cd newApp`.

### Test plan

1. create new project
2. `cd newProject` log should contain relative path