### PR TITLE
feat: handle child process termination when they're not exiting on kill signals

### DIFF
--- a/packages/plugin-platform-apple/src/lib/commands/build/buildProject.ts
+++ b/packages/plugin-platform-apple/src/lib/commands/build/buildProject.ts
@@ -1,5 +1,5 @@
 import { spinner } from '@clack/prompts';
-import { handleChildProcessTermination, logger, RnefError } from '@rnef/tools';
+import { logger, RnefError, setupChildProcessCleanup } from '@rnef/tools';
 import type { SubprocessError } from 'nano-spawn';
 import spawn from 'nano-spawn';
 import type { ApplePlatform, XcodeProjectInfo } from '../../types/index.js';
@@ -72,7 +72,7 @@ export const buildProject = async (
       cwd: sourceDir,
       stdio: logger.isVerbose() ? 'inherit' : ['ignore', 'pipe', 'pipe'],
     });
-    handleChildProcessTermination(childProcess);
+    setupChildProcessCleanup(childProcess);
     const { output } = await childProcess;
     loader.stop(
       `Built the app with xcodebuild for ${scheme} scheme in ${mode} mode.`

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -12,4 +12,4 @@ export * from './lib/build-cache/localBuildCache.js';
 export * from './lib/build-cache/remoteBuildCache.js';
 export * from './lib/build-cache/github/config.js';
 export * from './lib/build-cache/github/GitHubBuildCache.js';
-export { handleChildProcessTermination } from './lib/handleChildProcessTermination.js';
+export { setupChildProcessCleanup } from './lib/setupChildProcessCleanup.js';

--- a/packages/tools/src/lib/setupChildProcessCleanup.ts
+++ b/packages/tools/src/lib/setupChildProcessCleanup.ts
@@ -5,7 +5,7 @@ import type { Subprocess } from 'nano-spawn';
  * the parent process is terminated e.g. with SIGINT or SIGTERM signals.
  * This helper is intended for use in long-running tasks like building with xcodebuild, gradlew, bundling, etc.
  */
-export function handleChildProcessTermination(childProcess: Subprocess) {
+export function setupChildProcessCleanup(childProcess: Subprocess) {
   // overwrite @clack/prompts setting raw mode for spinner and prompts,
   // which prevents listening for SIGINT and SIGTERM
   process.stdin.setRawMode(false);


### PR DESCRIPTION

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Some spawn programs, like `xcodebuild`, fail to get signals, such as SIGINT, effectively keeping on running when a user killed the process in their terminal with Ctrl+C. It's not all programs, as `./gradlew` doesn't exhibit this issue – maybe they listen to Ctrl+C explicitly, but didn't dig into it. 

This PR adds the `handleChildProcessTermination` helper that handles killing a child process passed to it even when in the context of `@clack/prompts` helpers that are setting TTY to raw mode (which prevents listening for signals like SIGINT or SIGTERM)

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
