### PR TITLE
chore: handle RnefErrors as expected with less clutter

### DIFF
--- a/packages/cli/src/lib/cli.ts
+++ b/packages/cli/src/lib/cli.ts
@@ -54,13 +54,13 @@ export const cli = async ({ cwd, argv }: CliOptions = {}) => {
             if (error.cause) {
               logger.error(`Cause: ${error.cause}`);
             }
-            process.exit(1);
           } else {
             logger.error(
               `Unexpected error while running "${command.name}":`,
               error
             );
           }
+          process.exit(1);
         }
       });
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Currently errors caught by the action handler are super verbose, showing lots of unhelpful information, like stack internal stack traces. Instead, since we control RnefError flow, we can display nice `message` and stringified `cause` that are part of the error.

Before:
<img width="757" alt="Screenshot 2025-01-10 at 12 10 23" src="https://github.com/user-attachments/assets/e1038785-69e1-459c-9aa3-3255b03ef667" />

After:
<img width="765" alt="Screenshot 2025-01-10 at 12 09 40" src="https://github.com/user-attachments/assets/290f5658-9c12-4ad6-b597-6e4fd5b6e2d7" />

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
