### PR TITLE
fix: remove redundant setting of `-derivedDataPath` option

### DIFF
--- a/packages/plugin-platform-apple/src/lib/commands/build/buildProject.ts
+++ b/packages/plugin-platform-apple/src/lib/commands/build/buildProject.ts
@@ -60,18 +60,14 @@ export const buildProject = async (
     })(),
   ];
 
-  // TODO: handle case when someone pass --buildFolder
-
   if (args.archive) {
-    const { archiveDir, derivedDir } = getBuildPaths(platformName);
+    const { archiveDir } = getBuildPaths(platformName);
     const archiveName = `${xcodeProject.name.replace(
       '.xcworkspace',
       ''
     )}.xcarchive`;
 
     xcodebuildArgs.push(
-      '-derivedDataPath',
-      derivedDir,
       '-archivePath',
       path.join(archiveDir, archiveName),
       'archive'

--- a/packages/plugin-platform-apple/src/lib/utils/buildPaths.ts
+++ b/packages/plugin-platform-apple/src/lib/utils/buildPaths.ts
@@ -10,6 +10,5 @@ export const getBuildPaths = (platformName: string) => {
     buildDir,
     exportDir: path.join(buildDir, 'export'),
     archiveDir: path.join(buildDir, 'archive'),
-    derivedDir: path.join(buildDir, 'derived'),
   };
 };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR removes redundant setting of `derivedDataPath`. The same effect could be achieved just by using `--buildFolder` 👍

### Test plan

Using `build:ios --archive` should work as before.