### PR TITLE
fix: android tests not passing locally due to inherit stdio expectation

### DIFF
--- a/packages/plugin-platform-android/src/lib/commands/buildAndroid/__tests__/buildAndroid.test.ts
+++ b/packages/plugin-platform-android/src/lib/commands/buildAndroid/__tests__/buildAndroid.test.ts
@@ -86,7 +86,7 @@ test('buildAndroid runs gradle build with correct configuration for debug and ou
   await buildAndroid(androidProject, args);
 
   expect(spawn).toBeCalledWith('./gradlew', ['app:bundleDebug', '-x', 'lint'], {
-    stdio: 'pipe',
+    stdio: !tools.isInteractive() ? 'inherit' : 'pipe',
     cwd: '/android',
   });
   expect(spinnerMock.stop).toBeCalledWith(
@@ -106,7 +106,7 @@ test('buildAndroid fails gracefully when gradle errors', async () => {
   );
 
   expect(spawn).toBeCalledWith('./gradlew', ['app:bundleDebug', '-x', 'lint'], {
-    stdio: 'pipe',
+    stdio: !tools.isInteractive() ? 'inherit' : 'pipe',
     cwd: '/android',
   });
 });
@@ -143,7 +143,7 @@ test('buildAndroid runs selected "bundleRelease" task in interactive mode', asyn
     2,
     './gradlew',
     ['app:bundleRelease', '-x', 'lint'],
-    { stdio: 'pipe', cwd: '/android' }
+    { stdio: !tools.isInteractive() ? 'inherit' : 'pipe', cwd: '/android' }
   );
   expect(spinnerMock.start).toBeCalledWith(
     'Searching for available Gradle tasks...'

--- a/packages/plugin-platform-android/src/lib/commands/runAndroid/__tests__/runAndroid.test.ts
+++ b/packages/plugin-platform-android/src/lib/commands/runAndroid/__tests__/runAndroid.test.ts
@@ -323,7 +323,7 @@ test.each([['release'], ['debug'], ['staging']])(
         '-PreactNativeDevServerPort=8081',
         '-PreactNativeArchitectures=arm64-v8a,armeabi-v7a',
       ],
-      { stdio: 'pipe', cwd: '/android' }
+      { stdio: !tools.isInteractive() ? 'inherit' : 'pipe', cwd: '/android' }
     );
 
     // launches com.test app with MainActivity on emulator-5552
@@ -470,7 +470,7 @@ test.each([
         '-PreactNativeDevServerPort=8081',
         '-PreactNativeArchitectures=arm64-v8a,armeabi-v7a',
       ],
-      { stdio: 'pipe', cwd: '/android' }
+      { stdio: !tools.isInteractive() ? 'inherit' : 'pipe', cwd: '/android' }
     );
 
     // launches com.test app with MainActivity on emulator-5554
@@ -519,7 +519,7 @@ test('runAndroid launches an app on all connected devices', async () => {
       '-PreactNativeDevServerPort=8081',
       '-PreactNativeArchitectures=arm64-v8a,armeabi-v7a',
     ],
-    { stdio: 'pipe', cwd: '/android' }
+    { stdio: !tools.isInteractive() ? 'inherit' : 'pipe', cwd: '/android' }
   );
 
   // launches com.test app with MainActivity on emulator-5552


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Tests were passing on CI before, because in non-interactive environments we set the stdio to inherit, but they would fail locally. Adjusted tests to reflect these differences.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
