### PR TITLE
refactor: separate build and archive error flow

### DIFF
--- a/packages/plugin-platform-apple/src/lib/commands/build/createBuild.ts
+++ b/packages/plugin-platform-apple/src/lib/commands/build/createBuild.ts
@@ -74,12 +74,11 @@ export const createBuild = async (
         platformName,
         exportExtraParams: args.exportExtraParams ?? [],
       });
-
-      outro('Success 🎉.');
     } catch (error) {
       throw new RnefError('Failed to create archive', { cause: error });
     }
   }
+  outro('Success 🎉.');
 };
 
 function normalizeArgs(args: BuildFlags, xcodeProject: XcodeProjectInfo) {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

It happens that a build passes but archive fails (e.g. due to missing or invalid ExportOptions.plist). In such cases it's helpful to separate the error flow for the archive to a separate try/catch

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
