### PR TITLE
perf: inline loadConfigAsync call for 100ms speedup

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,4 +1,3 @@
-import { loadConfigAsync } from '@react-native-community/cli-config';
 import type {
   Config,
   DependencyConfig,
@@ -27,6 +26,9 @@ function filterConfig(config: Config) {
 }
 
 export const logConfig = async (options: { platform?: string }) => {
+  const { loadConfigAsync } = await import(
+    '@react-native-community/cli-config'
+  );
   const config = await loadConfigAsync({
     selectedPlatform: options.platform,
   });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Inline require of `@react-native-community/cli-config` to get a 100ms boost.
Hyperfine benchamark (lazy then static import) 
<img width="577" alt="image" src="https://github.com/user-attachments/assets/363e499c-9664-4a84-b8e5-213b414e0753" />


### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

`rnef config` and `rnef config -p` commands work.
