### PR TITLE
fix: update list of excluded directories

### DIFF
--- a/packages/tools/src/lib/fingerprint.ts
+++ b/packages/tools/src/lib/fingerprint.ts
@@ -36,6 +36,9 @@ export async function nativeFingerprint(
       'ios/DerivedData',
       'ios/Pods',
       'node_modules',
+      'android/local.properties',
+      'android/.idea',
+      'android/.gradle'
     ],
   });
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Found these dirs where causing different hash, after running `git clean -xdf` the hash was the same as the remote one. Added dirs that weren't excluded.