### PR TITLE
refactor(android): move `findOutputFile` fn

### DIFF
--- a/packages/plugin-platform-android/src/lib/commands/buildAndroid/buildAndroid.ts
+++ b/packages/plugin-platform-android/src/lib/commands/buildAndroid/buildAndroid.ts
@@ -2,7 +2,7 @@ import type { AndroidProjectConfig } from '@react-native-community/cli-types';
 import { logger, outro, parseArgs, spinner } from '@rnef/tools';
 import color from 'picocolors';
 import { promptForTaskSelection } from '../listAndroidTasks.js';
-import { findOutputFile } from '../runAndroid/tryInstallAppOnDevice.js';
+import { findOutputFile } from '../runAndroid/findOutputFile.js';
 import { runGradle } from '../runGradle.js';
 import { toPascalCase } from '../toPascalCase.js';
 

--- a/packages/plugin-platform-android/src/lib/commands/runAndroid/findOutputFile.ts
+++ b/packages/plugin-platform-android/src/lib/commands/runAndroid/findOutputFile.ts
@@ -1,0 +1,90 @@
+import { existsSync } from "node:fs";
+import { RnefError, spawn } from "@rnef/tools";
+import { getAdbPath } from "./adb.js";
+import type { AndroidProject } from "./runAndroid.js";
+
+export async function findOutputFile(
+  androidProject: AndroidProject,
+  tasks: string[],
+  device?: string
+) {
+  const { appName, sourceDir } = androidProject;
+  const selectedTask = tasks.find(
+    (t) =>
+      t.startsWith('install') ||
+      t.startsWith('assemble') ||
+      t.startsWith('bundle')
+  );
+  if (!selectedTask) {
+    return false;
+  }
+  // handle if selected task from interactive mode includes build flavour as well, eg. installProductionDebug should create ['production','debug'] array
+  const variantFromSelectedTask = selectedTask
+    ?.replace('install', '')
+    ?.replace('assemble', '')
+    ?.replace('bundle', '')
+    .split(/(?=[A-Z])/);
+
+  // create path to output file, eg. `production/debug`
+  const variantPath = variantFromSelectedTask?.join('/')?.toLowerCase();
+  // create output file name, eg. `production-debug`
+  const variantAppName = variantFromSelectedTask?.join('-')?.toLowerCase();
+  const apkOrBundle = selectedTask?.includes('bundle') ? 'bundle' : 'apk';
+  const buildDirectory = `${sourceDir}/${appName}/build/outputs/${apkOrBundle}/${variantPath}`;
+  const outputFile = await getInstallOutputFileName(
+    appName,
+    variantAppName,
+    buildDirectory,
+    apkOrBundle === 'apk' ? 'apk' : 'aab',
+    device
+  );
+  return `${buildDirectory}/${outputFile}`;
+}
+
+async function getInstallOutputFileName(
+  appName: string,
+  variant: string,
+  buildDirectory: string,
+  apkOrAab: 'apk' | 'aab',
+  device: string | undefined
+) {
+  const availableCPUs = await getAvailableCPUs(device);
+
+  // check if there is an apk file like app-armeabi-v7a-debug.apk
+  for (const availableCPU of availableCPUs.concat('universal')) {
+    const outputFile = `${appName}-${availableCPU}-${variant}.${apkOrAab}`;
+    if (existsSync(`${buildDirectory}/${outputFile}`)) {
+      return outputFile;
+    }
+  }
+
+  // check if there is a default file like app-debug.apk
+  const outputFile = `${appName}-${variant}.${apkOrAab}`;
+  if (existsSync(`${buildDirectory}/${outputFile}`)) {
+    return outputFile;
+  }
+
+  throw new RnefError(
+    `Could not find the correct .${apkOrAab} file to install.`
+  );
+}
+
+/**
+ * Gets available CPUs of devices from ADB
+ */
+async function getAvailableCPUs(device?: string) {
+  const adbPath = getAdbPath();
+  try {
+    const adbArgs = ['shell', 'getprop', 'ro.product.cpu.abilist'];
+
+    if (device) {
+      adbArgs.unshift('-s', device);
+    }
+
+    const { output } = await spawn(adbPath, adbArgs);
+
+    return output.trim().split(',');
+  } catch {
+    return [];
+  }
+}

--- a/packages/plugin-platform-android/src/lib/commands/runAndroid/tryInstallAppOnDevice.ts
+++ b/packages/plugin-platform-android/src/lib/commands/runAndroid/tryInstallAppOnDevice.ts
@@ -1,6 +1,6 @@
-import fs from 'node:fs';
-import { logger, RnefError, spawn, spinner } from '@rnef/tools';
+import { logger, spawn, spinner } from '@rnef/tools';
 import { getAdbPath } from './adb.js';
+import { findOutputFile } from './findOutputFile.js';
 import type { DeviceData } from './listAndroidDevices.js';
 import { promptForUser } from './listAndroidUsers.js';
 import type { AndroidProject, Flags } from './runAndroid.js';
@@ -66,91 +66,5 @@ export async function tryInstallAppOnDevice(
     loader.stop(
       `Installed the app on ${device.readableName} (id: ${deviceId}).`
     );
-  }
-}
-
-export async function findOutputFile(
-  androidProject: AndroidProject,
-  tasks: string[],
-  device?: string
-) {
-  const { appName, sourceDir } = androidProject;
-  const selectedTask = tasks.find(
-    (t) =>
-      t.startsWith('install') ||
-      t.startsWith('assemble') ||
-      t.startsWith('bundle')
-  );
-  if (!selectedTask) {
-    return false;
-  }
-  // handle if selected task from interactive mode includes build flavour as well, eg. installProductionDebug should create ['production','debug'] array
-  const variantFromSelectedTask = selectedTask
-    ?.replace('install', '')
-    ?.replace('assemble', '')
-    ?.replace('bundle', '')
-    .split(/(?=[A-Z])/);
-
-  // create path to output file, eg. `production/debug`
-  const variantPath = variantFromSelectedTask?.join('/')?.toLowerCase();
-  // create output file name, eg. `production-debug`
-  const variantAppName = variantFromSelectedTask?.join('-')?.toLowerCase();
-  const apkOrBundle = selectedTask?.includes('bundle') ? 'bundle' : 'apk';
-  const buildDirectory = `${sourceDir}/${appName}/build/outputs/${apkOrBundle}/${variantPath}`;
-  const outputFile = await getInstallOutputFileName(
-    appName,
-    variantAppName,
-    buildDirectory,
-    apkOrBundle === 'apk' ? 'apk' : 'aab',
-    device
-  );
-  return `${buildDirectory}/${outputFile}`;
-}
-
-async function getInstallOutputFileName(
-  appName: string,
-  variant: string,
-  buildDirectory: string,
-  apkOrAab: 'apk' | 'aab',
-  device: string | undefined
-) {
-  const availableCPUs = await getAvailableCPUs(device);
-
-  // check if there is an apk file like app-armeabi-v7a-debug.apk
-  for (const availableCPU of availableCPUs.concat('universal')) {
-    const outputFile = `${appName}-${availableCPU}-${variant}.${apkOrAab}`;
-    if (fs.existsSync(`${buildDirectory}/${outputFile}`)) {
-      return outputFile;
-    }
-  }
-
-  // check if there is a default file like app-debug.apk
-  const outputFile = `${appName}-${variant}.${apkOrAab}`;
-  if (fs.existsSync(`${buildDirectory}/${outputFile}`)) {
-    return outputFile;
-  }
-
-  throw new RnefError(
-    `Could not find the correct .${apkOrAab} file to install.`
-  );
-}
-
-/**
- * Gets available CPUs of devices from ADB
- */
-async function getAvailableCPUs(device?: string) {
-  const adbPath = getAdbPath();
-  try {
-    const adbArgs = ['shell', 'getprop', 'ro.product.cpu.abilist'];
-
-    if (device) {
-      adbArgs.unshift('-s', device);
-    }
-
-    const { output } = await spawn(adbPath, adbArgs);
-
-    return output.trim().split(',');
-  } catch {
-    return [];
   }
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Saw one stacktrace which failed in `findOutputFile` and it was confusing to me that it lives in `tryInstallApponDevice` and it was called from `build:ios` command. In this PR I just moved the function to separate file.