### PR TITLE
rename: other camelCased flags to kebab-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,5 +120,8 @@ npx create-rnef-app enterprise
 
    - `--mode` to `--build-variant` for Android commands
    - `--mode` to `--configuration` for iOS commands
+   - `--buildFolder` to `-build-folder` for iOS commands
+   - `--appId` to `--app-id` for Android commands
+   - `--appIdSuffix` to `--app-id-suffix` for Android commands
 
 1. Configure GitHub Actions for remote builds.

--- a/packages/plugin-platform-android/src/lib/commands/runAndroid/runAndroid.ts
+++ b/packages/plugin-platform-android/src/lib/commands/runAndroid/runAndroid.ts
@@ -218,13 +218,13 @@ export const runOptions = [
     default: process.env['RCT_METRO_PORT'] || '8081',
   },
   {
-    name: '--appId <string>',
+    name: '--app-id <string>',
     description:
       'Specify an applicationId to launch after build. If not specified, `package` from AndroidManifest.xml will be used.',
     default: '',
   },
   {
-    name: '--appIdSuffix <string>',
+    name: '--app-id-suffix <string>',
     description: 'Specify an applicationIdSuffix to launch after build.',
     default: '',
   },

--- a/packages/plugin-platform-apple/src/lib/commands/build/buildOptions.ts
+++ b/packages/plugin-platform-apple/src/lib/commands/build/buildOptions.ts
@@ -66,7 +66,7 @@ export const getBuildOptions = ({ platformName }: BuilderCommand) => {
       description: 'Run on Mac Catalyst.',
     },
     {
-      name: '--buildFolder <string>',
+      name: '--build-folder <string>',
       description: `Location for ${readableName} build artifacts. Corresponds to Xcode's "-derivedDataPath".`,
       value: 'build',
     },

--- a/packages/plugin-platform-ios/template/.github/actions/rnef-remote-build-ios/action.yml
+++ b/packages/plugin-platform-ios/template/.github/actions/rnef-remote-build-ios/action.yml
@@ -140,7 +140,7 @@ runs:
         npx rnef build:ios \
           ${{ inputs.destination == 'device' && '--archive' || '' }} \
           --configuration ${{ inputs.configuration }} \
-          --buildFolder "build" \
+          --build-folder "build" \
           ${{ inputs.rnef-build-extra-params }}
       shell: bash
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

With these flags converted to kebab-case we're fully consistent across all packages. And commander will give a helpful hint in case someone uses old naming:

<img width="279" alt="image" src="https://github.com/user-attachments/assets/2b9055c5-e2d7-48b1-9184-acd4f800bc43" />


### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
