### PR TITLE
fix: clack spinner.stop() outputting "undefined" in verbose mode

### DIFF
--- a/packages/tools/src/lib/prompts.ts
+++ b/packages/tools/src/lib/prompts.ts
@@ -104,7 +104,9 @@ export function spinner() {
   if (logger.isVerbose() || !isInteractive()) {
     return {
       start: (message?: string) => logger.log(message),
-      stop: (message?: string, code?: number) => logger.log(message, code),
+      stop: (message?: string, code = 0) => {
+        return code === 0 ? logger.log(message) : logger.error(message);
+      },
       message: (message?: string) => logger.log(message),
     };
   }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

In verbose mode `spinner.stop()` always added `undefined` at the end of the message.

![CleanShot 2025-02-04 at 12 22 34@2x](https://github.com/user-attachments/assets/5e3745aa-84e1-4d86-b7ce-dd44754ba266)


<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
