### PR TITLE
Move rn-cli-plugin to peer deps

### DIFF
--- a/packages/plugin-metro/package.json
+++ b/packages/plugin-metro/package.json
@@ -18,8 +18,10 @@
   "dependencies": {
     "@rnef/tools": "^0.1.6",
     "@react-native-community/cli-server-api": "^16.0.2",
-    "@react-native/community-cli-plugin": "0.77.0-rc.2",
     "tslib": "^2.3.0"
+  },
+  "peerDependencies" : {
+    "@react-native/community-cli-plugin": "*"
   },
   "devDependencies": {
     "@rnef/config": "^0.1.6"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Installing metro plugin throws an error when installing with specific prod dependency set. This is due to the install of rn-cli-plugin. Moving to peer deps as it should re-use what's already installed.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
