### PR TITLE
feat: determine sourceDir and appName from config

### DIFF
--- a/packages/plugin-platform-android/template/.github/actions/rnef-remote-build-android/action.yml
+++ b/packages/plugin-platform-android/template/.github/actions/rnef-remote-build-android/action.yml
@@ -120,10 +120,20 @@ runs:
         echo "RNEF_UPLOAD_KEY_PASSWORD=${{ inputs.keystore-key-password }}" >> $HOME/.gradle/gradle.properties
       shell: bash
 
+    - name: Determine Android sourceDir and appName
+      if: ${{ !steps.cached-url.outputs.artifact-url }}
+      run: |
+        JSON_OUTPUT=$(npx rnef config -p android)
+        ANDROID_SOURCE_DIR=$(echo "$JSON_OUTPUT" | jq -r '.project.android.sourceDir')
+        APP_NAME=$(echo "$JSON_OUTPUT" | jq -r '.project.android.appName')
+        echo "ANDROID_SOURCE_DIR=$ANDROID_SOURCE_DIR" >> $GITHUB_ENV
+        echo "APP_NAME=$APP_NAME" >> $GITHUB_ENV
+      shell: bash
+
     - name: Decode and store keystore file
       if: ${{ !steps.cached-url.outputs.artifact-url && inputs.sign }}
       run: |
-        echo "${{ inputs.keystore-base64 }}" | base64 --decode > android/app/release.keystore
+        echo "${{ inputs.keystore-base64 }}" | base64 --decode > $ANDROID_SOURCE_DIR/$APP_NAME/release.keystore
       shell: bash
 
     - name: Build Android
@@ -137,7 +147,7 @@ runs:
     - name: Find Build Artifact
       if: ${{ !steps.cached-url.outputs.artifact-url }}
       run: |
-        APK_PATH=$(find android/app/build/outputs -name '*.apk' | head -1 )
+        APK_PATH=$(find $ANDROID_SOURCE_DIR/$APP_NAME/build/outputs -name '*.apk' | head -1 )
         echo APK_PATH $APK_PATH
         echo "ARTIFACT_PATH=$APK_PATH" >> $GITHUB_ENV
       shell: bash
@@ -155,7 +165,7 @@ runs:
       if: ${{ !steps.cached-url.outputs.artifact-url && inputs.sign }}
       run: |
         rm $HOME/.gradle/gradle.properties
-        rm android/app/release.keystore
+        rm $ANDROID_SOURCE_DIR/$APP_NAME/release.keystore
       shell: bash
 
     - name: Post Build

--- a/packages/plugin-platform-ios/template/.github/actions/rnef-remote-build-ios/action.yml
+++ b/packages/plugin-platform-ios/template/.github/actions/rnef-remote-build-ios/action.yml
@@ -100,7 +100,7 @@ runs:
       with:
         title: iOS ${{ inputs.configuration }} ${{ inputs.destination == 'simulator' && 'APP for simulators' || 'IPA for physical devices' }}
         artifact-url: ${{ steps.cached-url.outputs.artifact-url }}
-    
+
     - name: Setup Code Signing (device builds only)
       if: ${{ !steps.cached-url.outputs.artifact-url && inputs.destination == 'device' }}
       run: |
@@ -127,10 +127,18 @@ runs:
         echo -n "${{ inputs.provisioning-profile-base64 }}" | base64 --decode -o "$PROFILE_PATH"
       shell: bash
 
+    - name: Determine iOS sourceDir
+      if: ${{ !steps.cached-url.outputs.artifact-url }}
+      run: |
+        JSON_OUTPUT=$(npx rnef config -p ios)
+        IOS_SOURCE_DIR=$(echo "$JSON_OUTPUT" | jq -r '.project.ios.sourceDir')
+        echo "IOS_SOURCE_DIR=$IOS_SOURCE_DIR" >> $GITHUB_ENV
+      shell: bash
+
     - name: Install Pods
       if: ${{ !steps.cached-url.outputs.artifact-url }}
       run: |
-        cd ios
+        cd $IOS_SOURCE_DIR
         pod install
       shell: bash
 
@@ -153,7 +161,7 @@ runs:
           echo "ARTIFACT_PATH=$IPA_PATH" >> $GITHUB_ENV
         else 
           # Simulator build: needs to compress with tar, as GH actions drop execute file permission during packing to zip
-          APP_PATH=$(find ios/build -name '*.app' -type d | head -1 )
+          APP_PATH=$(find $IOS_SOURCE_DIR/build -name '*.app' -type d | head -1 )
           APP_DIR=$(dirname "$APP_PATH")
           APP_BASENAME=$(basename "$APP_PATH")
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

These are not hardcoded in some projects:
- `ios/` dir, can be configured through `project.ios.sourceDir`
- `android/` dir, can be configured through `project.android.sourceDir`
- `android/app/` dir, can be configured through `project.android.appName`

### Test plan

https://github.com/callstack-internal/rnef-remote-build-test/pull/13
