### PR TITLE
chore: sync versions in template with actual

### DIFF
--- a/packages/platform-android/template/package.json
+++ b/packages/platform-android/template/package.json
@@ -4,6 +4,6 @@
     "android": "rnef run:android"
   },
   "devDependencies": {
-    "@rnef/platform-android": "^0.1.7"
+    "@rnef/platform-android": "^0.2.0"
   }
 }

--- a/packages/platform-ios/template/package.json
+++ b/packages/platform-ios/template/package.json
@@ -4,6 +4,6 @@
     "ios": "rnef run:ios"
   },
   "devDependencies": {
-    "@rnef/platform-ios": "^0.1.7"
+    "@rnef/platform-ios": "^0.2.0"
   }
 }

--- a/packages/plugin-metro/template/package.json
+++ b/packages/plugin-metro/template/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rnef-plugin-metro-template",
   "devDependencies": {
-    "@rnef/plugin-metro": "^0.1.7",
+    "@rnef/plugin-metro": "^0.2.0",
     "@react-native/metro-config": "0.77.0-rc.2"
   }
 }

--- a/packages/plugin-repack/template/package.json
+++ b/packages/plugin-repack/template/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rnef-plugin-repack-template",
   "devDependencies": {
-    "@rnef/plugin-repack": "^0.1.7",
+    "@rnef/plugin-repack": "^0.2.0",
     "@callstack/repack": "^5.0.0-rc.4",
     "@rspack/core": "^1.1.3",
     "@rspack/plugin-react-refresh": "^1.0.0",

--- a/templates/rnef-template-default/package.json
+++ b/templates/rnef-template-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rnef/template-default",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "scripts": {
     "start": "rnef start",
     "lint": "eslint .",
@@ -16,7 +16,7 @@
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
     "@babel/runtime": "^7.25.0",
-    "@rnef/cli": "^0.1.7",
+    "@rnef/cli": "^0.2.0",
     "@expo/fingerprint": "^0.11.6",
     "@react-native/babel-preset": "0.77.0-rc.2",
     "@react-native/eslint-config": "0.77.0-rc.2",


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

So we did bump packages to `0.2.0` and also there was a change in packages' names which leads to a failure when installing packages in a new project:

```
 ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @rnef/platform-android@^0.1.7

This error happened while installing a direct dependency of /Users/szymonrybczak/callstack/tmp/pol

The latest release of @rnef/platform-android is "0.2.0".
```

In this PR I bumped the versions of packages in templates so it points to a correct one.

### Test plan

1. Create new project by following tutorial in the CONTRIBUTING.md and install packages. Everything should pass.