### PR TITLE
chore: don't say verbose error is unexpected when it isn't

### DIFF
--- a/.changeset/itchy-snakes-shop.md
+++ b/.changeset/itchy-snakes-shop.md
@@ -1,0 +1,5 @@
+---
+'@rnef/cli': patch
+---
+
+chore: don't say verbose error is unexpected when it isn't

--- a/packages/cli/src/lib/cli.ts
+++ b/packages/cli/src/lib/cli.ts
@@ -51,10 +51,14 @@ export const cli = async ({ cwd, argv }: CliOptions = {}) => {
         try {
           await command.action(...args);
         } catch (error) {
-          if (!logger.isVerbose() && error instanceof RnefError) {
-            logger.error(error.message);
-            if (error.cause) {
-              logger.error(`Cause: ${error.cause}`);
+          if (error instanceof RnefError) {
+            if (logger.isVerbose()) {
+              logger.error(error);
+            } else {
+              logger.error(error.message);
+              if (error.cause) {
+                logger.error(`Cause: ${error.cause}`);
+              }
             }
           } else {
             logger.error(


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Currently we say a RnefError is unexpected when we're in verbose mode. This is unintended, so fixing this logic so it's not misleading.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
