### PR TITLE
docs: link CI docs from main readme, CI permissions, CI secrets, npm install command fix

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -1,3 +1,16 @@
+# General
+## Secrets
+To use the RNEF GitHub Actions, you need to set up the secrets on your GitHub repository:
+`NPM_TOKEN` and 
+platforms specific secrets described below in the iOS and Android sections.
+
+## Change workflow permissions 
+Settings -> Actions -> General -> Workflow Permissions -> Read and write permissions
+
+## Generate GitHub Personal Access Token for downloading cached builds 
+Generate GitHub Personal Access Token for downloading cached builds at: https://github.com/settings/tokens. Include "repo", "workflow", and "read:org" permissions.
+You'll be asked about this token when cached build is available while running the `npx rnef run:` command.
+
 # iOS CI Builds
 
 ## Development Builds For Simulators

--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ npx create-rnef-app enterprise
    - `--appId` to `--app-id` for Android commands
    - `--appIdSuffix` to `--app-id-suffix` for Android commands
 
-1. Configure GitHub Actions for remote builds.
+1. Configure GitHub Actions for remote builds as per [CI Docs](CI.md)


### PR DESCRIPTION
### Summary
Fixed the `npm install -D` command
Linked CI readme from the main readme 
Added sections in CI readme: secrets ( NPM_TOKEN ), workflow permissions, personal access token 

### Test plan
N/A