### PR TITLE
feat: update template dependencies during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,9 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm run version
+          version: |
+            pnpm run version
+            ./scripts/update-template-dependencies.sh
           commit: 'chore: version packages'
           title: 'chore: version packages'
           publish: pnpm publish:npm

--- a/scripts/update-template-dependencies.sh
+++ b/scripts/update-template-dependencies.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+echo "Updating all @rnef/* dependencies to match CLI version..."
+
+# Get the version from packages/cli/package.json
+CLI_VERSION=$(jq -r '.version' packages/cli/package.json)
+echo "Using CLI version: $CLI_VERSION"
+
+# Function to update package.json files
+update_package_json() {
+    local file=$1
+    echo "Processing $file..."
+    
+    # Create a temporary file
+    temp_file=$(mktemp)
+    
+    # Update all @rnef/* dependencies to match CLI version
+    jq --arg version "^$CLI_VERSION" '
+        # Only update if the field exists
+        if has("dependencies") then
+            .dependencies = (
+                .dependencies | 
+                to_entries | 
+                map(if .key | startswith("@rnef/") then .value = $version else . end) |
+                from_entries
+            )
+        else . end |
+        
+        if has("devDependencies") then
+            .devDependencies = (
+                .devDependencies | 
+                to_entries | 
+                map(if .key | startswith("@rnef/") then .value = $version else . end) |
+                from_entries
+            )
+        else . end
+    ' "$file" > "$temp_file"
+    
+    # Replace the original file with the updated one
+    mv "$temp_file" "$file"
+}
+
+# Find all package.json files in templates directory and update them
+find ./templates -name "package.json" -not -path "*/node_modules/*" | while read -r file; do
+    update_package_json "$file"
+done
+
+# Find all package.json files in packages/*/template directories and update them
+find ./packages -path "*/template/*" -name "package.json" -not -path "*/node_modules/*" | while read -r file; do
+    update_package_json "$file"
+done
+
+echo "Done! All @rnef/* dependencies have been updated to version ^$CLI_VERSION." 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Currently when doing releases we have to manually update bumped `@rnef/*` dependencies to match the new ones and as it is manual process it can lead to some mismatches and issues.

In this PR I added a script which will be executed during release which reads version of `@rnef/cli` package and goes through all `package.json#dependencies` & `package.json#devDependencies` fields in `./templates` and `./packages/*/template` directories and updates them to `^${version}`.

### Test plan

Trigger a release to test the full flow.

You can also test only script part by first bumping version in `packages/cli/package.json`:
```diff
{
  "name": "@rnef/cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
  "type": "module",
  "exports": {
    "./package.json": "./package.json"
  },

```
and then by running `./scripts/update-template-dependencies.sh`, this output should be visible with relevant changes in printed files.

```
Updating all @rnef/* dependencies to match CLI version...
Using CLI version: 0.4.2
Processing ./templates/rnef-template-default/package.json...
Processing ./packages/plugin-repack/template/package.json...
Processing ./packages/platform-ios/template/package.json...
Processing ./packages/plugin-metro/template/package.json...
Processing ./packages/platform-android/template/package.json...
Done! All @rnef/* dependencies have been updated to version ^0.4.2.
```

For example:

```diff
    "ios": "rnef run:ios"
  },
  "devDependencies": {
-    "@rnef/platform-ios": "^0.4.1"
+    "@rnef/platform-ios": "^0.4.2"
  }
}


```

