### PR TITLE
feat: sync start command options with upstream

### DIFF
--- a/packages/plugin-metro/src/lib/pluginMetro.ts
+++ b/packages/plugin-metro/src/lib/pluginMetro.ts
@@ -41,6 +41,7 @@ type StartCommandArgs = {
   watchFolders?: string[];
   config?: string;
   projectRoot?: string;
+  clientLogs?: boolean;
   interactive: boolean;
 };
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

I thought we'll need to update also command definitions, but it looks like it's all handled by `community-cli-plugin`, so just a small type update here :)

### Test plan

`rnef start --client-logs`
