### PR TITLE
fix: update github-token, cliFile, fixup destination on non-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ npx @rnef/create-app enterprise
 
    ```diff
    -// cliFile = file("../../node_modules/react-native/cli.js")
-   +cliFile = file("../../node_modules/@rnef/cli/src/bin.js")
+   +cliFile = file("../../node_modules/@rnef/cli/dist/src/bin.js")
    ```
 
    In `android/settings.gradle` change:

--- a/packages/cli/src/lib/checkDeprecatedOptions.ts
+++ b/packages/cli/src/lib/checkDeprecatedOptions.ts
@@ -74,7 +74,6 @@ const deprecatedAndroidFlags = [
 const deprecatedIosFlags = [
   { old: '--mode', new: '--configuration' },
   { old: '--buildFolder', new: '--build-folder' },
-  { old: '--destination', new: '--destinations' },
 ];
 
 export const checkDeprecatedOptions = (argv: string[]) => {

--- a/packages/platform-android/template/.github/workflows/remote-build-android.yml
+++ b/packages/platform-android/template/.github/workflows/remote-build-android.yml
@@ -34,12 +34,13 @@ jobs:
         with:
           sign: true
           variant: release
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           keystore-base64: ${{ secrets.KEYSTORE_BASE64 }}
           keystore-store-file: ${{ secrets.RNEF_UPLOAD_STORE_FILE }}
           keystore-store-password: ${{ secrets.RNEF_UPLOAD_STORE_PASSWORD }}
           keystore-key-alias: ${{ secrets.RNEF_UPLOAD_KEY_ALIAS }}
           keystore-key-password: ${{ secrets.RNEF_UPLOAD_KEY_PASSWORD }}
-  
+
   build-debug:
     runs-on: ubuntu-latest
 
@@ -60,3 +61,4 @@ jobs:
         uses: callstackincubator/android@v1
         with:
           variant: debug
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/platform-apple-helpers/src/lib/commands/build/buildOptions.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/build/buildOptions.ts
@@ -11,7 +11,7 @@ export type BuildFlags = {
   exportExtraParams?: string[];
   exportOptionsPlist?: string;
   buildFolder?: string;
-  destination?: string;
+  destination?: 'device' | 'simulator';
   destinations?: string[];
   archive?: boolean;
   installPods: boolean;

--- a/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/run/createRun.ts
@@ -49,7 +49,7 @@ export const createRun = async (
   if (!args.binaryPath && args.remoteCache) {
     const cachedBuild = await fetchCachedBuild({
       configuration: args.configuration ?? 'Debug',
-      distribution: args.device ? 'device' : 'simulator', // TODO: replace with better logic
+      distribution: args.destination ?? (args.device ? 'device' : 'simulator'),
       remoteCacheProvider,
       root: projectRoot,
       fingerprintOptions,
@@ -208,7 +208,6 @@ export const createRun = async (
 
   outro('Success 🎉.');
 };
-
 
 async function selectDevice(devices: Device[], args: RunFlags) {
   let device;

--- a/packages/platform-ios/template/.github/workflows/remote-build-ios.yml
+++ b/packages/platform-ios/template/.github/workflows/remote-build-ios.yml
@@ -33,6 +33,7 @@ jobs:
         uses: callstackincubator/ios@v1
         with:
           destination: device
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           scheme: SCHEME_FOR_DEVICES # replace with preferred scheme
           configuration: Release # replace with preferred configuration
           certificate-base64: ${{ secrets.APPLE_BUILD_CERTIFICATE_BASE64 }}
@@ -61,5 +62,6 @@ jobs:
         uses: callstackincubator/ios@v1
         with:
           destination: simulator
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           scheme: SCHEME_FOR_SIMULATORS # replace with preferred scheme
           configuration: Debug # replace with preferred configuration

--- a/website/docs/docs/getting-started/migrating-from-community-cli.mdx
+++ b/website/docs/docs/getting-started/migrating-from-community-cli.mdx
@@ -39,7 +39,7 @@ import { PackageManagerTabs } from 'rspress/theme';
 
    ```groovy title="android/app/build.gradle" {2}
    // cliFile = file("../../node_modules/react-native/cli.js")
-   cliFile = file("../../node_modules/@rnef/cli/src/bin.js")
+   cliFile = file("../../node_modules/@rnef/cli/dist/src/bin.js")
    ```
 
    In `android/settings.gradle` change:
@@ -110,6 +110,7 @@ import { PackageManagerTabs } from 'rspress/theme';
      uses: ./.github/actions/rnef-remote-build-ios
      with:
        destination: simulator
+       github-token: ${{ secrets.GITHUB_TOKEN }}
        configuration: Debug
    ```
 
@@ -121,6 +122,7 @@ import { PackageManagerTabs } from 'rspress/theme';
      uses: ./.github/actions/rnef-remote-build-android
      with:
        variant: debug
+       github-token: ${{ secrets.GITHUB_TOKEN }}
    ```
 
    For more setup options see [GitHub Actions configuration](../remote-cache/github-actions/configuration.md)


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Multiple small fixes:
- missing github-token in docs
- incorrect cliFile path in docs
- destination flag firing a warning that's no longer valid

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
