### PR TITLE
fix: wrap booting simulator in try catch and add special case for when it says it's booted already

### DIFF
--- a/.changeset/silent-trainers-rescue.md
+++ b/.changeset/silent-trainers-rescue.md
@@ -1,0 +1,5 @@
+---
+'@rnef/platform-apple-helpers': patch
+---
+
+fix: wrap booting simulator in try catch and add special case for when it says it's booted already

--- a/packages/platform-apple-helpers/src/lib/commands/run/runOnSimulator.ts
+++ b/packages/platform-apple-helpers/src/lib/commands/run/runOnSimulator.ts
@@ -56,7 +56,7 @@ async function bootSimulator(selectedSimulator: Device) {
         'Unable to boot device in current state: Booted'
       )
     ) {
-      logger.debug(`Simulator already booted. Skipping.`);
+      logger.debug(`Simulator ${selectedSimulator.udid} already booted. Skipping.`);
       return;
     }
     throw new RnefError('Failed to boot Simulator', {


### PR DESCRIPTION
### Summary

It may happen on GitHub Actions when the simulator is already booted, even though the simctl returns its state as Shutdown

<img width="973" alt="image" src="https://github.com/user-attachments/assets/68587aef-a55e-4070-b385-02e9b26a4e6b" />

Wrapped that in try/catch (which was missing) and added a special case

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
