### PR TITLE
docs: attribute @expo/fingerprint

### DIFF
--- a/website/docs/docs/configuration/index.md
+++ b/website/docs/docs/configuration/index.md
@@ -179,3 +179,5 @@ export default {
   },
 };
 ```
+
+The fingerprint calculation uses [`@expo/fingerprint`](https://docs.expo.dev/versions/latest/sdk/fingerprint/) under the hood.

--- a/website/docs/docs/getting-started/introduction.md
+++ b/website/docs/docs/getting-started/introduction.md
@@ -103,7 +103,7 @@ Out of the box we support storing artifacts on GitHub Actions and we're working 
 
 ### How It Works
 
-1. For each build, we calculate a unique hash (fingerprint) that represents your project's native state
+1. For each build, we calculate a unique hash (fingerprint) with [`@expo/fingerprint`](https://docs.expo.dev/versions/latest/sdk/fingerprint/) that represents your project's native state
 2. This hash remains stable across builds unless you:
    - Modify native files
    - Change native dependencies


### PR DESCRIPTION
the fingerprint feature uses @expo/fingerprint internally, so we should mention them