### PR TITLE
chore: whitelist dependencies in the monorepo

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
 packages:
   - packages/*
   - website
+
+onlyBuiltDependencies:
+  - '@swc/core'
+  - core-js
+  - esbuild
+  - nx


### PR DESCRIPTION
### Summary

newer pnpm versions prevent these dependencies from running their postinstall scripts, added them to whitelist

### Test plan

n/a
