### PR TITLE
docs: add missing json imports on Android

### DIFF
--- a/website/docs/docs/brownfield/android.md
+++ b/website/docs/docs/brownfield/android.md
@@ -243,6 +243,9 @@ plugins {
 Configure the publishing settings:
 
 ```groovy title="rnbrownfield/build.gradle.kts"
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+
 publishing {
     publications {
         create<MavenPublication>("mavenAar") {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

Add missing `JsonOutput` and `JsonSlurper` imports necessary by the `publishing` section on Android.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
