### PR TITLE
docs: add missing mavenLocal repository on Android

### DIFF
--- a/website/docs/docs/brownfield/android.md
+++ b/website/docs/docs/brownfield/android.md
@@ -335,7 +335,17 @@ tasks.named("generateMetadataFileForMavenAarPublication") {
 
 > Note: You'll need an existing Android app or create a new one in Android Studio.
 
-1. Add the dependency to your app's `build.gradle.kts`:
+1. Add `mavenLocal()` to your app's dependency resolution in `settings.gradle.kts`:
+
+   ```groovy title="settings.gradle.kts" {3}
+    dependencyResolutionManagement {
+        repositories {
+            mavenLocal()
+        }
+    }
+   ```
+
+2. Add the dependency to your app's `build.gradle.kts`:
 
    ```groovy title="build.gradle.kts" {2}
    dependencies {
@@ -343,7 +353,7 @@ tasks.named("generateMetadataFileForMavenAarPublication") {
    }
    ```
 
-1. Initialize React Native in your `MainActivity`:
+3. Initialize React Native in your `MainActivity`:
 
    ```kotlin
    class MainActivity : AppCompatActivity() {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Add missing `mavenLocal()` repository in the `dependencyResolutionManagement.repositories` field in `settings.gradle.kts`.

Without this, the host app is unable to find the published AAR in the local maven repository.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
