### PR TITLE
fix: add types declaration to project packages package.json files

### DIFF
--- a/.changeset/nasty-islands-melt.md
+++ b/.changeset/nasty-islands-melt.md
@@ -1,0 +1,16 @@
+---
+'@rnef/plugin-brownfield-android': patch
+'@rnef/platform-apple-helpers': patch
+'@rnef/plugin-brownfield-ios': patch
+'@rnef/platform-android': patch
+'@rnef/provider-github': patch
+'@rnef/plugin-repack': patch
+'@rnef/platform-ios': patch
+'@rnef/plugin-metro': patch
+'@rnef/provider-s3': patch
+'@rnef/create-app': patch
+'@rnef/config': patch
+'@rnef/tools': patch
+---
+
+Add types field to package.json files

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -2,6 +2,7 @@
   "name": "@rnef/config",
   "version": "0.8.3",
   "type": "module",
+  "types": "./dist/src/index.d.ts",
   "exports": {
     "types": "./dist/src/index.d.ts",
     "default": "./dist/src/index.js"

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -2,6 +2,7 @@
   "name": "@rnef/create-app",
   "version": "0.8.3",
   "type": "module",
+  "types": "./dist/src/index.d.ts",
   "exports": {
     "types": "./dist/src/index.d.ts",
     "default": "./dist/src/index.js"

--- a/packages/platform-android/package.json
+++ b/packages/platform-android/package.json
@@ -2,6 +2,7 @@
   "name": "@rnef/platform-android",
   "version": "0.8.3",
   "type": "module",
+  "types": "./dist/src/index.d.ts",
   "exports": {
     "types": "./dist/src/index.d.ts",
     "default": "./dist/src/index.js"

--- a/packages/platform-apple-helpers/package.json
+++ b/packages/platform-apple-helpers/package.json
@@ -2,6 +2,7 @@
   "name": "@rnef/platform-apple-helpers",
   "version": "0.8.3",
   "type": "module",
+  "types": "./dist/src/index.d.ts",
   "exports": {
     "types": "./dist/src/index.d.ts",
     "default": "./dist/src/index.js"

--- a/packages/platform-ios/package.json
+++ b/packages/platform-ios/package.json
@@ -2,6 +2,7 @@
   "name": "@rnef/platform-ios",
   "version": "0.8.3",
   "type": "module",
+  "types": "./dist/src/index.d.ts",
   "exports": {
     "types": "./dist/src/index.d.ts",
     "default": "./dist/src/index.js"

--- a/packages/plugin-brownfield-android/package.json
+++ b/packages/plugin-brownfield-android/package.json
@@ -2,6 +2,7 @@
   "name": "@rnef/plugin-brownfield-android",
   "version": "0.8.3",
   "type": "module",
+  "types": "./dist/src/index.d.ts",
   "exports": {
     "types": "./dist/src/index.d.ts",
     "default": "./dist/src/index.js"

--- a/packages/plugin-brownfield-ios/package.json
+++ b/packages/plugin-brownfield-ios/package.json
@@ -2,6 +2,7 @@
   "name": "@rnef/plugin-brownfield-ios",
   "version": "0.8.3",
   "type": "module",
+  "types": "./dist/src/index.d.ts",
   "exports": {
     "types": "./dist/src/index.d.ts",
     "default": "./dist/src/index.js"

--- a/packages/plugin-metro/package.json
+++ b/packages/plugin-metro/package.json
@@ -2,6 +2,7 @@
   "name": "@rnef/plugin-metro",
   "version": "0.8.3",
   "type": "module",
+  "types": "./dist/src/index.d.ts",
   "exports": {
     "types": "./dist/src/index.d.ts",
     "default": "./dist/src/index.js"

--- a/packages/plugin-repack/package.json
+++ b/packages/plugin-repack/package.json
@@ -2,6 +2,7 @@
   "name": "@rnef/plugin-repack",
   "version": "0.8.3",
   "type": "module",
+  "types": "./dist/src/index.d.ts",
   "exports": {
     "types": "./dist/src/index.d.ts",
     "default": "./dist/src/index.js"

--- a/packages/provider-github/package.json
+++ b/packages/provider-github/package.json
@@ -2,6 +2,7 @@
   "name": "@rnef/provider-github",
   "version": "0.8.3",
   "type": "module",
+  "types": "./dist/src/index.d.ts",
   "exports": {
     "types": "./dist/src/index.d.ts",
     "default": "./dist/src/index.js"

--- a/packages/provider-s3/package.json
+++ b/packages/provider-s3/package.json
@@ -2,6 +2,7 @@
   "name": "@rnef/provider-s3",
   "version": "0.8.3",
   "type": "module",
+  "types": "./dist/src/index.d.ts",
   "exports": {
     "types": "./dist/src/index.d.ts",
     "default": "./dist/src/index.js"

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -2,6 +2,7 @@
   "name": "@rnef/tools",
   "version": "0.8.3",
   "type": "module",
+  "types": "./dist/src/index.d.ts",
   "exports": {
     "types": "./dist/src/index.d.ts",
     "default": "./dist/src/index.js"


### PR DESCRIPTION
### Summary

When I developed an RNEF plugin for RN Legal, I wanted to use types from the @rnef/config packages (e.g., PluginApi).
When I included them in the project, `tsc` couldn't build it due to a lack of types. 

When I import them like this, I have TSC error:
```
import {PluginApi} from '@rnef/config';
```

When I use full path, TSC is ok with that:
```
import {PluginApi} from '@rnef/config/dist/src';
```

When I added a line below to `package.json` in `@rnef/config` package I could use this kind of import without any error: `import {PluginApi} from '@rnef/config';`
```
"types": "./dist/src/index.d.ts",
```

I see all the packages registered in the `path` section of the main `tsconfig.base.json`, and `tsc` internally knows where they are. When I used it as a separate package without any additional configuration, the problem occurred.

As a fix, I've copied the type declaration from the `exports` section in every non-private package in the repo.

### Test plan

1. Prepare some simple JS project with package.json, dependency on `@rnef/config`, and with TypeScript.
2. In the main js file use `import {PluginApi} from '@rnef/config';` and use type declaration in the script. Please fix all TS errors, such as unused variables, etc.
3. run tsc

Expected outcome:
No errors

What happens:
I see the error like:
```
src/index.ts:1:25 - error TS2307: Cannot find module '@rnef/config' or its corresponding type declarations.
  There are types at '/Users/wiktor.jaszczuk/Projects/react-native-legal/node_modules/@rnef/config/dist/src/index.d.ts', but this result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.
```

I have attached a link to my repository branch, where I have included the code with the bug reproduction. https://github.com/wjaszczuk/react-native-legal/tree/rnef-ts-declaration-bug-example

1. Download the `rnef-ts-declaration-bug-example` branch from `wjaszczuk/react-native-legal` repository and run yarn there in the main project directory.

