### PR TITLE
chore: upgrade theme to 0.3.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,8 +447,8 @@ importers:
   website:
     dependencies:
       '@callstack/rspress-theme':
-        specifier: ^0.3.0
-        version: 0.3.0(react@19.1.0)(rspress@2.0.0-beta.21(@types/react@19.1.8)(acorn@8.14.0)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.17))))
+        specifier: ^0.3.1
+        version: 0.3.1(react@19.1.0)(rspress@2.0.0-beta.21(@types/react@19.1.8)(acorn@8.14.0)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.17))))
       '@rspress/plugin-llms':
         specifier: 2.0.0-beta.21
         version: 2.0.0-beta.21(rspress@2.0.0-beta.21(@types/react@19.1.8)(acorn@8.14.0)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.17))))
@@ -813,8 +813,8 @@ packages:
       webpack:
         optional: true
 
-  '@callstack/rspress-theme@0.3.0':
-    resolution: {integrity: sha512-s49tbcA2rblHtCcypvST54t/JkjQ3iF7kfr7PUvNsSpIYtka9Pe0r0GY11IBB+2DeZfflcwxEQBpSV/amgivGQ==}
+  '@callstack/rspress-theme@0.3.1':
+    resolution: {integrity: sha512-oBuZqVoNDisr+brNQNa+azPwSbBolN7DmC4T80BxPFYlBOsM4rLz3yZLbxJBL5pD/ujaez9BN/h/inBuZs2WfQ==}
     peerDependencies:
       react: ^19.0.0
       rspress: ^2.0.0-beta.21
@@ -7165,7 +7165,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@callstack/rspress-theme@0.3.0(react@19.1.0)(rspress@2.0.0-beta.21(@types/react@19.1.8)(acorn@8.14.0)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.17))))':
+  '@callstack/rspress-theme@0.3.1(react@19.1.0)(rspress@2.0.0-beta.21(@types/react@19.1.8)(acorn@8.14.0)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.17))))':
     dependencies:
       react: 19.1.0
       rspress: 2.0.0-beta.21(@types/react@19.1.8)(acorn@8.14.0)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.17)))

--- a/website/package.json
+++ b/website/package.json
@@ -8,7 +8,7 @@
     "preview": "rspress preview"
   },
   "dependencies": {
-    "@callstack/rspress-theme": "^0.3.0",
+    "@callstack/rspress-theme": "^0.3.1",
     "@rspress/plugin-llms": "2.0.0-beta.21",
     "rsbuild-plugin-open-graph": "^1.0.2",
     "rspress": "2.0.0-beta.21",


### PR DESCRIPTION
### Summary

- [x] - upgraded `@callstack/rspress-theme` to `0.3.1`

### Test plan

n/a
