### PR TITLE
fix: auto replace scheme name in iOS build actions

### DIFF
--- a/packages/platform-ios/template/.github/workflows/remote-build-ios.yml
+++ b/packages/platform-ios/template/.github/workflows/remote-build-ios.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           destination: device
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          scheme: SCHEME_FOR_DEVICES # replace with preferred scheme
+          scheme: HelloWorld
           configuration: Release # replace with preferred configuration
           certificate-base64: ${{ secrets.APPLE_BUILD_CERTIFICATE_BASE64 }}
           certificate-password: ${{ secrets.APPLE_BUILD_CERTIFICATE_PASSWORD }}
@@ -63,5 +63,5 @@ jobs:
         with:
           destination: simulator
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          scheme: SCHEME_FOR_SIMULATORS # replace with preferred scheme
+          scheme: HelloWorld
           configuration: Debug # replace with preferred configuration


### PR DESCRIPTION
### Summary

This PR makes sure that users don't need to manually change `SCHEME_FOR_DEVICES` while creating new app.

The scheme name is exactly the same as project name so we can just replace that.

### Test plan

Initialize new project and check GitHub actions workflow file