### PR TITLE
feat: move fingerprint debugging logs behind debug flag

### DIFF
--- a/.changeset/wide-roses-hang.md
+++ b/.changeset/wide-roses-hang.md
@@ -1,0 +1,5 @@
+---
+'rock': patch
+---
+
+move fingerprint debugging logs behind debug flag

--- a/packages/cli/src/lib/plugins/fingerprint.ts
+++ b/packages/cli/src/lib/plugins/fingerprint.ts
@@ -15,6 +15,7 @@ import {
 type NativeFingerprintCommandOptions = {
   platform: 'ios' | 'android';
   raw?: boolean;
+  debug?: boolean;
 };
 
 export async function nativeFingerprintCommand(
@@ -34,17 +35,19 @@ export async function nativeFingerprintCommand(
       env,
     });
     console.log(fingerprint.hash);
-    // log sources to stderr to avoid polluting the standard output
-    console.error(
-      JSON.stringify(
-        {
-          hash: fingerprint.hash,
-          sources: fingerprint.inputs.filter((source) => source.hash != null),
-        },
-        null,
-        2,
-      ),
-    );
+    if (options.debug) {
+      // log sources to stderr to avoid polluting the standard output
+      console.error(
+        JSON.stringify(
+          {
+            hash: fingerprint.hash,
+            sources: fingerprint.inputs.filter((source) => source.hash != null),
+          },
+          null,
+          2,
+        ),
+      );
+    }
     return;
   }
 
@@ -109,6 +112,10 @@ export const fingerprintPlugin = () => (api: PluginApi) => {
       {
         name: '--raw',
         description: 'Output the raw fingerprint hash for piping',
+      },
+      {
+        name: '--debug',
+        description: 'Output additional debugging information',
       },
     ],
     args: [


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Add a debug feature flag to fingerprint and avoid logging full context by default.

### Test plan

Test locally that the context is no longer logged unless debug is specified.
