### PR TITLE
fix(create-app): preserve existing arg list when patching Podfile

### DIFF
--- a/.changeset/podfile-patch-preserve-args.md
+++ b/.changeset/podfile-patch-preserve-args.md
@@ -1,0 +1,5 @@
+---
+'create-rock': patch
+---
+
+fix(create-app): preserve existing arg list when patching Podfile

--- a/packages/create-app/src/lib/utils/__tests__/initInExistingProject.test.ts
+++ b/packages/create-app/src/lib/utils/__tests__/initInExistingProject.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { cleanup, getTempDirectory, writeFiles } from '@rock-js/test-helpers';
 import * as tools from '@rock-js/tools';
-import { updateAndroidBuildGradle } from '../initInExistingProject.js';
+import { updateAndroidBuildGradle, updatePodfile } from '../initInExistingProject.js';
 
 const directory = getTempDirectory('test_updateAndroidBuildGradle');
 
@@ -120,3 +120,73 @@ describe('updateAndroidBuildGradle', () => {
     );
   });
 });
+
+describe('updatePodfile', () => {
+  it('replaces a bare `use_native_modules!` call (Community-CLI template)', () => {
+    const content = `
+target 'App' do
+  config = use_native_modules!
+
+  use_react_native!(:path => config[:reactNativePath])
+end
+`;
+    const expected = `
+target 'App' do
+  config = use_native_modules!(['npx', 'rock', 'config', '-p', 'ios'])
+
+  use_react_native!(:path => config[:reactNativePath])
+end
+`;
+    writeFiles(directory, { 'ios/Podfile': content });
+    updatePodfile(directory, 'ios');
+
+    expect(
+      fs.readFileSync(path.join(directory, 'ios/Podfile'), 'utf8'),
+    ).toStrictEqual(expected);
+  });
+
+  it('replaces a `use_native_modules!(config_command)` call (Expo prebuild template, regression test for #702)', () => {
+    const content = `
+target 'App' do
+  config_command = ['node', '--no-warnings', '--eval', "require('expo/bin/autolinking')"]
+  config = use_native_modules!(config_command)
+
+  use_react_native!(:path => config[:reactNativePath])
+end
+`;
+    const expected = `
+target 'App' do
+  config_command = ['node', '--no-warnings', '--eval', "require('expo/bin/autolinking')"]
+  config = use_native_modules!(['npx', 'rock', 'config', '-p', 'ios'])
+
+  use_react_native!(:path => config[:reactNativePath])
+end
+`;
+    writeFiles(directory, { 'ios/Podfile': content });
+    updatePodfile(directory, 'ios');
+
+    expect(
+      fs.readFileSync(path.join(directory, 'ios/Podfile'), 'utf8'),
+    ).toStrictEqual(expected);
+  });
+
+  it('is idempotent — running on an already-patched Podfile is a no-op', () => {
+    const content = `
+target 'App' do
+  config = use_native_modules!(['npx', 'rock', 'config', '-p', 'ios'])
+end
+`;
+    writeFiles(directory, { 'ios/Podfile': content });
+    updatePodfile(directory, 'ios');
+
+    expect(
+      fs.readFileSync(path.join(directory, 'ios/Podfile'), 'utf8'),
+    ).toStrictEqual(content);
+  });
+
+  it('does nothing when there is no Podfile', () => {
+    // No Podfile written; updatePodfile should return without throwing.
+    expect(() => updatePodfile(directory, 'ios')).not.toThrow();
+  });
+});
+

--- a/packages/create-app/src/lib/utils/initInExistingProject.ts
+++ b/packages/create-app/src/lib/utils/initInExistingProject.ts
@@ -271,15 +271,21 @@ Please update the "Bundle React Native code and images" build phase manually wit
   );
 }
 
-function updatePodfile(projectRoot: string, sourceDir: string) {
+export function updatePodfile(projectRoot: string, sourceDir: string) {
   const filePath = path.join(projectRoot, sourceDir, 'Podfile');
   if (!fs.existsSync(filePath)) {
     return;
   }
   const content = fs.readFileSync(filePath, 'utf8');
+  // Replace `config = use_native_modules!` together with any existing
+  // argument list. The Community-CLI Podfile template calls it with no
+  // arguments (`use_native_modules!`), but the Expo prebuild template
+  // passes its own autolinking command in (`use_native_modules!(config_command)`).
+  // Without consuming that argument the previous regex left it dangling
+  // on the line and produced invalid Ruby — see issue #702.
   const replaced = content.replace(
-    /(config\s*=\s*use_native_modules!)(\s*)/g,
-    "$1(['npx', 'rock', 'config', '-p', 'ios'])$2",
+    /(config\s*=\s*use_native_modules!)(\s*\([^)]*\))?/g,
+    "$1(['npx', 'rock', 'config', '-p', 'ios'])",
   );
   if (
     !content.includes(`(['npx', 'rock', 'config', '-p', 'ios'])`) &&


### PR DESCRIPTION
## Summary

Fixes #702 — `npm create rock` produces an invalid `ios/Podfile` on Expo prebuild projects.

`updatePodfile` in `packages/create-app/src/lib/utils/initInExistingProject.ts` ran a regex that matched `config = use_native_modules!` plus the whitespace after `!`, but not any existing argument list. That worked for the Community-CLI Podfile template (which calls `use_native_modules!` with no arguments), but Expo's prebuild template calls it with `config_command` as the argument. The patch then inserted Rock's array right before the existing `(config_command)`, leaving two consecutive call expressions on the same line — invalid Ruby:

```ruby
config = use_native_modules!(['npx', 'rock', 'config', '-p', 'ios'])(config_command)
                                                                    ^ unexpected '('
```

Every subsequent `pod install` (and therefore every `rock run:ios`) failed on Expo projects after `npm create rock`.

## Fix

Extend the regex to also consume any existing parenthesized argument list, so it gets replaced in full:

```diff
- /(config\s*=\s*use_native_modules!)(\s*)/g,
- "$1(['npx', 'rock', 'config', '-p', 'ios'])$2",
+ /(config\s*=\s*use_native_modules!)(\s*\([^)]*\))?/g,
+ "$1(['npx', 'rock', 'config', '-p', 'ios'])",
```

On Community-CLI Podfiles the optional group matches nothing — behaviour is unchanged. On Expo prebuild Podfiles the existing `(config_command)` is now consumed and replaced cleanly.

## Tests

Added four `updatePodfile` cases to `packages/create-app/src/lib/utils/__tests__/initInExistingProject.test.ts`:

- Community-CLI template (bare `use_native_modules!`) — regression coverage for the old happy path
- Expo prebuild template (`use_native_modules!(config_command)`) — the case #702 reports
- Idempotency on an already-patched Podfile (no-op)
- Missing Podfile is a no-op

`updatePodfile` is now exported, mirroring the existing `updateAndroidBuildGradle` export used by neighbouring tests.

```
 ✓ src/lib/utils/__tests__/initInExistingProject.test.ts (9 tests) 11ms

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

## Verified manually

In a fresh Expo SDK 55 / RN 0.83 project with prebuilt `ios/`:

1. With the unpatched Rock 0.13.0: `npm create rock` → broken Podfile → `pnpm rock run:ios` fails with `unexpected '('` in `pod install`.
2. With this patch applied locally: `npm create rock` → Podfile line is `config = use_native_modules!(['npx', 'rock', 'config', '-p', 'ios'])` → `pod install` proceeds normally.

## Notes

- The trailing-whitespace capture `($2 ` → `(\s*)$2)` in the old regex was unnecessary — whitespace following the match was not being consumed by the regex anyway, so dropping the second capture has no behavioural impact beyond simpler substitution.
- The Expo prebuild template has shipped `use_native_modules!(config_command)` for a long time; this fix unlocks migration for every Expo-CNG project, not just SDK 55.
