### PR TITLE
fix: add and normalize package metadata to fix OIDC publishing

### DIFF
--- a/.changeset/tough-rivers-own.md
+++ b/.changeset/tough-rivers-own.md
@@ -1,0 +1,23 @@
+---
+'create-rock': patch
+'rock': patch
+'expo-config-plugins-test-app': patch
+'@rock-js/config': patch
+'@rock-js/platform-android': patch
+'@rock-js/platform-apple-helpers': patch
+'@rock-js/platform-harmony': patch
+'@rock-js/platform-ios': patch
+'@rock-js/plugin-brownfield-android': patch
+'@rock-js/plugin-brownfield-ios': patch
+'@rock-js/plugin-expo-config-plugins': patch
+'@rock-js/plugin-metro': patch
+'@rock-js/plugin-repack': patch
+'@rock-js/provider-github': patch
+'@rock-js/provider-s3': patch
+'@rock-js/test-helpers': patch
+'@rock-js/tools': patch
+'@rock-js/welcome-screen': patch
+'rock-docs': patch
+---
+
+fix: add and normalize package metadata to fix OIDC publishing

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,7 @@
     "./package.json": "./package.json"
   },
   "bin": {
-    "rock": "./dist/src/bin.js"
+    "rock": "dist/src/bin.js"
   },
   "files": [
     "dist"

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -19,7 +19,7 @@
     "e2e": "CI=true vitest --config vite.e2e.config.js"
   },
   "bin": {
-    "create-rock": "./dist/src/bin.js"
+    "create-rock": "dist/src/bin.js"
   },
   "devDependencies": {
     "@rock-js/test-helpers": "^0.13.1",

--- a/templates/rock-template-default/package.json
+++ b/templates/rock-template-default/package.json
@@ -33,5 +33,14 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/callstackincubator/rock.git",
+    "directory": "templates/rock-template-default"
+  },
+  "homepage": "https://rockjs.dev",
+  "bugs": "https://github.com/callstackincubator/rock/issues",
+  "license": "MIT",
+  "author": "Callstack <incubator@callstack.com>"
 }


### PR DESCRIPTION
This PR:
- adds missing metadata for `rock-template-default`, which fixes OIDC publishing for that package
- normalizes bin paths which NPM warns about when publishing