### PR TITLE
feat(plugin-expo-config-plugins): withRockAutolinking — Expo CNG config plugin

### DIFF
--- a/packages/plugin-expo-config-plugins/src/index.ts
+++ b/packages/plugin-expo-config-plugins/src/index.ts
@@ -1,1 +1,8 @@
 export * from './lib/pluginExpoConfigPlugins.js';
+export {
+  default as withRockAutolinking,
+  patchAndroidBuildGradle,
+  patchAndroidSettingsGradle,
+  patchPodfile,
+  patchXcodeProject,
+} from './lib/config-plugin/withRockAutolinking.js';

--- a/packages/plugin-expo-config-plugins/src/lib/config-plugin/__tests__/withRockAutolinking.test.ts
+++ b/packages/plugin-expo-config-plugins/src/lib/config-plugin/__tests__/withRockAutolinking.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import {
+  patchAndroidBuildGradle,
+  patchAndroidSettingsGradle,
+  patchPodfile,
+  patchXcodeProject,
+} from '../withRockAutolinking.js';
+
+describe('patchPodfile', () => {
+  it('rewrites the Community-CLI bare call', () => {
+    const input = `target 'App' do
+  config = use_native_modules!
+
+  use_react_native!(:path => config[:reactNativePath])
+end
+`;
+    const expected = `target 'App' do
+  config = use_native_modules!(['npx', 'rock', 'config', '-p', 'ios'])
+
+  use_react_native!(:path => config[:reactNativePath])
+end
+`;
+    expect(patchPodfile(input)).toBe(expected);
+  });
+
+  it('rewrites the Expo prebuild call with an existing argument', () => {
+    const input = `target 'App' do
+  config_command = ['node', '-e', "require('expo/bin/autolinking')"]
+  config = use_native_modules!(config_command)
+end
+`;
+    const expected = `target 'App' do
+  config_command = ['node', '-e', "require('expo/bin/autolinking')"]
+  config = use_native_modules!(['npx', 'rock', 'config', '-p', 'ios'])
+end
+`;
+    expect(patchPodfile(input)).toBe(expected);
+  });
+
+  it('is idempotent on an already-patched Podfile', () => {
+    const input = `target 'App' do
+  config = use_native_modules!(['npx', 'rock', 'config', '-p', 'ios'])
+end
+`;
+    expect(patchPodfile(input)).toBe(input);
+  });
+});
+
+describe('patchAndroidBuildGradle', () => {
+  it('replaces a commented-out cliFile', () => {
+    const input = `
+      react {
+        // cliFile = file("../../node_modules/react-native/cli.js")
+      }
+    `;
+    const expected = `
+      react {
+        cliFile = file("../../node_modules/rock/dist/src/bin.js")
+      }
+    `;
+    expect(patchAndroidBuildGradle(input)).toBe(expected);
+  });
+
+  it('replaces a live cliFile pointing at react-native', () => {
+    const input = `
+      react {
+        cliFile = file("\${reactNativeDir}/cli.js")
+      }
+    `;
+    const expected = `
+      react {
+        cliFile = file("../../node_modules/rock/dist/src/bin.js")
+      }
+    `;
+    expect(patchAndroidBuildGradle(input)).toBe(expected);
+  });
+
+  it('is idempotent on an already-patched file', () => {
+    const input = `
+      react {
+        cliFile = file("../../node_modules/rock/dist/src/bin.js")
+      }
+    `;
+    expect(patchAndroidBuildGradle(input)).toBe(input);
+  });
+});
+
+describe('patchAndroidSettingsGradle', () => {
+  it('replaces the full configure block', () => {
+    const input = `
+rootProject.name = 'App'
+include ':app'
+extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand(['node', '-e', "require('@react-native-community/cli').run()"]) }
+`;
+    const out = patchAndroidSettingsGradle(input);
+    expect(out).toContain("autolinkLibrariesFromCommand(['npx', 'rock', 'config', '-p', 'android'])");
+    expect(out).not.toContain('@react-native-community/cli');
+  });
+
+  it('falls back to replacing just the inner call', () => {
+    const input = `someUnrelatedScope { autolinkLibrariesFromCommand(['foo']) }`;
+    const out = patchAndroidSettingsGradle(input);
+    expect(out).toContain("autolinkLibrariesFromCommand(['npx', 'rock', 'config', '-p', 'android'])");
+  });
+
+  it('is idempotent', () => {
+    const input = `autolinkLibrariesFromCommand(['npx', 'rock', 'config', '-p', 'android'])`;
+    expect(patchAndroidSettingsGradle(input)).toBe(input);
+  });
+});
+
+describe('patchXcodeProject', () => {
+  it('rewrites the default Community-CLI build phase shellScript', () => {
+    const original =
+      'shellScript = "set -e\\n\\nWITH_ENVIRONMENT=\\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\\"\\nREACT_NATIVE_XCODE=\\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\\"\\n\\n/bin/sh -c \\"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\\"\\n";';
+    const out = patchXcodeProject(original);
+    expect(out).toContain("require.resolve('rock/package.json')");
+    expect(out).not.toContain('REACT_NATIVE_XCODE=');
+  });
+
+  it('rewrites the RN 0.83 build phase shellScript', () => {
+    const original =
+      'shellScript = "set -e\\n\\nWITH_ENVIRONMENT=\\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\\"\\nREACT_NATIVE_XCODE=\\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\\"\\n\\n/bin/sh -c \\"\\\\\\"$WITH_ENVIRONMENT\\\\\\" \\\\\\"$REACT_NATIVE_XCODE\\\\\\"\\"\\n";';
+    const out = patchXcodeProject(original);
+    expect(out).toContain("require.resolve('rock/package.json')");
+  });
+
+  it('is idempotent on an already-patched pbxproj', () => {
+    const patched =
+      'shellScript = "set -e\\nif [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\nsource \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\nsource \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\nexport CONFIG_CMD=\\"dummy-workaround-value\\"\\nexport CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require(\'path\').dirname(require.resolve(\'rock/package.json\')) + \'/dist/src/bin.js\'\\")\\"\\nWITH_ENVIRONMENT=\\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\\"\\n";';
+    expect(patchXcodeProject(patched)).toBe(patched);
+  });
+
+  it('leaves unrelated pbxproj content untouched', () => {
+    const input = `// some random pbxproj content without the target phase`;
+    expect(patchXcodeProject(input)).toBe(input);
+  });
+});

--- a/packages/plugin-expo-config-plugins/src/lib/config-plugin/withRockAutolinking.ts
+++ b/packages/plugin-expo-config-plugins/src/lib/config-plugin/withRockAutolinking.ts
@@ -1,0 +1,176 @@
+// Expo Config Plugin that re-applies Rock's autolinking patches on
+// every `expo prebuild`. Designed to live in `app.config.ts plugins:
+// ['@rock-js/plugin-expo-config-plugins']` so the patches survive
+// Expo CNG (Continuous Native Generation) regenerating `ios/` and
+// `android/` from scratch.
+//
+// Mirrors the one-shot transforms in
+// `packages/create-app/src/lib/utils/initInExistingProject.ts`:
+//   - iOS Podfile        — point `use_native_modules!` at Rock
+//   - Android build.gradle — point `cliFile` at Rock's bin.js
+//   - Android settings.gradle — point `autolinkLibrariesFromCommand`
+//                                at Rock
+//   - Xcode project.pbxproj — rewrite the React Native build phase
+//                              shellScript to source Rock's CLI
+//
+// Each step is idempotent so repeated prebuilds don't break.
+
+import { type ConfigPlugin, withDangerousMod } from '@expo/config-plugins';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// ----- iOS / Podfile ---------------------------------------------------------
+
+export function patchPodfile(content: string): string {
+  if (content.includes(`(['npx', 'rock', 'config', '-p', 'ios'])`)) {
+    // Already patched — leave alone (idempotent).
+    return content;
+  }
+  return content.replace(
+    /(config\s*=\s*use_native_modules!)(\s*\([^)]*\))?/g,
+    "$1(['npx', 'rock', 'config', '-p', 'ios'])",
+  );
+}
+
+const withRockIosPodfile: ConfigPlugin = (config) =>
+  withDangerousMod(config, [
+    'ios',
+    async (cfg) => {
+      const podfilePath = path.join(cfg.modRequest.platformProjectRoot, 'Podfile');
+      if (!fs.existsSync(podfilePath)) return cfg;
+      const original = await fs.promises.readFile(podfilePath, 'utf8');
+      const patched = patchPodfile(original);
+      if (patched !== original) {
+        await fs.promises.writeFile(podfilePath, patched);
+      }
+      return cfg;
+    },
+  ]);
+
+// ----- iOS / Xcode project.pbxproj ------------------------------------------
+
+const XCODE_REACT_PHASE_TARGET =
+  'shellScript = "set -e\\nif [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\nsource \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\nsource \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\nexport CONFIG_CMD=\\"dummy-workaround-value\\"\\nexport CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require(\'path\').dirname(require.resolve(\'rock/package.json\')) + \'/dist/src/bin.js\'\\")\\"\\nWITH_ENVIRONMENT=\\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\\"\\n";';
+
+const XCODE_REACT_PHASE_SOURCES = [
+  // Default Expo / Community-CLI format
+  'shellScript = "set -e\\n\\nWITH_ENVIRONMENT=\\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\\"\\nREACT_NATIVE_XCODE=\\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\\"\\n\\n/bin/sh -c \\"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\\"\\n";',
+  // RN 0.83 format
+  'shellScript = "set -e\\n\\nWITH_ENVIRONMENT=\\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\\"\\nREACT_NATIVE_XCODE=\\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\\"\\n\\n/bin/sh -c \\"\\\\\\"$WITH_ENVIRONMENT\\\\\\" \\\\\\"$REACT_NATIVE_XCODE\\\\\\"\\"\\n";',
+];
+
+export function patchXcodeProject(content: string): string {
+  if (content.includes(XCODE_REACT_PHASE_TARGET)) {
+    return content;
+  }
+  for (const source of XCODE_REACT_PHASE_SOURCES) {
+    if (content.includes(source)) {
+      return content.replace(source, XCODE_REACT_PHASE_TARGET);
+    }
+  }
+  return content;
+}
+
+const withRockIosXcode: ConfigPlugin = (config) =>
+  withDangerousMod(config, [
+    'ios',
+    async (cfg) => {
+      const iosDir = cfg.modRequest.platformProjectRoot;
+      const xcodeProjectFolder = (await fs.promises.readdir(iosDir)).find((f) =>
+        f.endsWith('.xcodeproj'),
+      );
+      if (!xcodeProjectFolder) return cfg;
+      const projectPath = path.join(iosDir, xcodeProjectFolder, 'project.pbxproj');
+      if (!fs.existsSync(projectPath)) return cfg;
+      const original = await fs.promises.readFile(projectPath, 'utf8');
+      const patched = patchXcodeProject(original);
+      if (patched !== original) {
+        await fs.promises.writeFile(projectPath, patched);
+      }
+      return cfg;
+    },
+  ]);
+
+// ----- Android / app/build.gradle -------------------------------------------
+
+const ANDROID_CLI_FILE_TARGET = 'cliFile = file("../../node_modules/rock/dist/src/bin.js")';
+
+export function patchAndroidBuildGradle(content: string): string {
+  if (content.includes(ANDROID_CLI_FILE_TARGET)) {
+    return content;
+  }
+  return content.replace(
+    /(?:\/\/\s+)?cliFile\s*=\s*file\([^)]*\)/g,
+    ANDROID_CLI_FILE_TARGET,
+  );
+}
+
+// ----- Android / settings.gradle --------------------------------------------
+
+const ANDROID_AUTOLINK_TARGET =
+  "autolinkLibrariesFromCommand(['npx', 'rock', 'config', '-p', 'android'])";
+
+export function patchAndroidSettingsGradle(content: string): string {
+  if (content.includes(ANDROID_AUTOLINK_TARGET)) {
+    return content;
+  }
+  // Try the full block first (`extensions.configure(...) { ... }`)…
+  const blockPattern =
+    /extensions\.configure\(com\.facebook\.react\.ReactSettingsExtension\)\{[^}]*autolinkLibrariesFromCommand\([^)]*\)[^}]*\}/gs;
+  const blockReplacement = `extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.${ANDROID_AUTOLINK_TARGET} }`;
+  if (blockPattern.test(content)) {
+    return content.replace(blockPattern, blockReplacement);
+  }
+  // …otherwise fall back to replacing just the inner call.
+  return content.replace(/autolinkLibrariesFromCommand\([^)]*\)/g, ANDROID_AUTOLINK_TARGET);
+}
+
+const withRockAndroid: ConfigPlugin = (config) =>
+  withDangerousMod(config, [
+    'android',
+    async (cfg) => {
+      const androidDir = cfg.modRequest.platformProjectRoot;
+      const appBuildGradlePath = path.join(androidDir, 'app', 'build.gradle');
+      const settingsGradlePath = path.join(androidDir, 'settings.gradle');
+
+      if (fs.existsSync(appBuildGradlePath)) {
+        const original = await fs.promises.readFile(appBuildGradlePath, 'utf8');
+        const patched = patchAndroidBuildGradle(original);
+        if (patched !== original) {
+          await fs.promises.writeFile(appBuildGradlePath, patched);
+        }
+      }
+      if (fs.existsSync(settingsGradlePath)) {
+        const original = await fs.promises.readFile(settingsGradlePath, 'utf8');
+        const patched = patchAndroidSettingsGradle(original);
+        if (patched !== original) {
+          await fs.promises.writeFile(settingsGradlePath, patched);
+        }
+      }
+      return cfg;
+    },
+  ]);
+
+// ----- Top-level plugin -----------------------------------------------------
+
+/**
+ * Expo Config Plugin that re-applies Rock's autolinking patches to the
+ * native dirs generated by `expo prebuild`. Add it once to
+ * `app.config.ts` `plugins`:
+ *
+ *   plugins: [
+ *     '@rock-js/plugin-expo-config-plugins/withRockAutolinking',
+ *     // …
+ *   ],
+ *
+ * Idempotent — repeated `expo prebuild --clean` runs converge on the
+ * same patched files.
+ */
+export const withRockAutolinking: ConfigPlugin = (config) => {
+  config = withRockIosPodfile(config);
+  config = withRockIosXcode(config);
+  config = withRockAndroid(config);
+  return config;
+};
+
+export default withRockAutolinking;


### PR DESCRIPTION
## Summary

Draft for #707 — adds an Expo Config Plugin (`withRockAutolinking`) to `@rock-js/plugin-expo-config-plugins` that re-applies Rock's autolinking patches on every `expo prebuild`, so they survive Expo CNG regenerating `ios/` + `android/` from scratch.

User wires it once into `app.config.ts`:

```ts
export default {
  // …
  plugins: [
    '@rock-js/plugin-expo-config-plugins/withRockAutolinking',
    // …
  ],
};
```

After that, `pnpm clear:prebuild` (or any `expo prebuild --clean`) leaves a Podfile / project.pbxproj / Gradle files that Rock can drive — no manual `npm create rock` re-run after every prebuild.

## What it patches

Each transform mirrors the one-shot transform in `packages/create-app/src/lib/utils/initInExistingProject.ts`:

| File | Transform |
|---|---|
| `ios/Podfile` | `use_native_modules!(config_command)` → `use_native_modules!(['npx', 'rock', 'config', '-p', 'ios'])` |
| `ios/<App>.xcodeproj/project.pbxproj` | React Native build phase `shellScript` → sources Rock's CLI via `require.resolve('rock/package.json')` (handles both the default Community-CLI shellScript and the RN 0.83 format) |
| `android/app/build.gradle` | `cliFile = file(...react-native/cli.js)` → `cliFile = file("../../node_modules/rock/dist/src/bin.js")` |
| `android/settings.gradle` | `autolinkLibrariesFromCommand(...)` → Rock's command, full configure block or just the inner call as a fallback |

Each step is **idempotent**: repeated prebuilds converge on the same file. Already-patched content is detected and short-circuited.

## Structure

- `packages/plugin-expo-config-plugins/src/lib/config-plugin/withRockAutolinking.ts`
  - Four pure string-in/string-out helpers (`patchPodfile`, `patchXcodeProject`, `patchAndroidBuildGradle`, `patchAndroidSettingsGradle`)
  - Three `withDangerousMod` wrappers (`withRockIosPodfile`, `withRockIosXcode`, `withRockAndroid`)
  - Top-level composed `ConfigPlugin` exported as default + named `withRockAutolinking`
- `packages/plugin-expo-config-plugins/src/index.ts` — re-exports `withRockAutolinking` + the patch helpers
- `packages/plugin-expo-config-plugins/src/lib/config-plugin/__tests__/withRockAutolinking.test.ts` — 13 unit tests

## Tests

```
 ✓ src/lib/config-plugin/__tests__/withRockAutolinking.test.ts (13 tests) 2ms

 Test Files  1 passed (1)
      Tests  13 passed (13)
```

Each helper covered for:
- Community-CLI input (bare `use_native_modules!`, default shellScript, default `cliFile`, default `autolinkLibrariesFromCommand`)
- Expo prebuild input where the call already has an argument (`use_native_modules!(config_command)`, variable-substituted `cliFile`, etc.)
- Idempotency (already-patched input → no-op)
- Unrelated content stays untouched

## Status: draft

Marking as **draft** because:

1. **`patchXcodeProject` is brittle.** It matches the build phase shellScript with two literal Xcode-emitted strings. RN versions other than 0.83 and the latest Community-CLI default will silently miss. Either: extend the source set as users hit it, or rewrite to parse pbxproj (e.g. via `@expo/config-plugins`' `IOSConfig.XcodeUtils`). I'd appreciate a steer on which direction the project wants.
2. **Android settings.gradle fallback may over-match.** `autolinkLibrariesFromCommand` could appear inside multiple `extensions.configure` blocks in unusual setups. The full-block pattern catches the common Expo-generated shape; the fallback regex replaces every occurrence. Wider real-world testing needed.
3. **No e2e / integration test against a fresh `expo prebuild`** output yet — only unit tests against representative snippets. Once I have CI access to a Rock dev environment I can wire one up; happy to add it if there's an obvious harness already in the repo I missed.
4. **No README / docs update** in `packages/plugin-expo-config-plugins/README.md` yet — wanted maintainer sign-off on plugin name + import path before I write user-facing docs.

Happy to take any of those further (e.g. switch to a pbxproj parser, scope the Android regex, add docs) before this gets merged.

## Related

- Issue: #707
- Sibling PR: #703 (regex bug in the one-shot `updatePodfile` migrator). The two fixes are independent — #703 helps Community-CLI projects on the migration boundary; this one keeps Expo CNG projects working long-term.
