### PR TITLE
fix: remove metadata required for OIDC from extracted app template

### DIFF
--- a/.changeset/upset-keys-stop.md
+++ b/.changeset/upset-keys-stop.md
@@ -1,0 +1,5 @@
+---
+'create-rock': patch
+---
+
+fix: remove metadata required for OIDC from extracted app template

--- a/packages/create-app/src/lib/__tests__/stripTemplatePackageJsonMetadata.test.ts
+++ b/packages/create-app/src/lib/__tests__/stripTemplatePackageJsonMetadata.test.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, expect, test } from 'vitest';
+import { stripTemplatePackageJsonMetadata } from '../stripTemplatePackageJsonMetadata.js';
+
+let tmpDir: string;
+
+afterEach(() => {
+  if (tmpDir && fs.existsSync(tmpDir)) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('stripTemplatePackageJsonMetadata removes template npm metadata keys', () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'create-app-pkg-'));
+  const packageJsonPath = path.join(tmpDir, 'package.json');
+  fs.writeFileSync(
+    packageJsonPath,
+    JSON.stringify({
+      name: 'my-app',
+      version: '1.0.0',
+      private: true,
+      repository: { type: 'git', url: 'https://example.com/repo.git' },
+      homepage: 'https://example.com',
+      bugs: 'https://example.com/issues',
+      license: 'MIT',
+      author: 'ACME',
+      scripts: { start: 'rock start' },
+    }),
+  );
+
+  stripTemplatePackageJsonMetadata(tmpDir);
+
+  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+  expect(pkg.name).toBe('my-app');
+  expect(pkg.repository).toBeUndefined();
+  expect(pkg.homepage).toBeUndefined();
+  expect(pkg.bugs).toBeUndefined();
+  expect(pkg.license).toBeUndefined();
+  expect(pkg.author).toBeUndefined();
+  expect(pkg.scripts).toEqual({ start: 'rock start' });
+});
+
+test('stripTemplatePackageJsonMetadata is a no-op when package.json is missing', () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'create-app-pkg-'));
+  expect(() => stripTemplatePackageJsonMetadata(tmpDir)).not.toThrow();
+});

--- a/packages/create-app/src/lib/bin.ts
+++ b/packages/create-app/src/lib/bin.ts
@@ -22,6 +22,7 @@ import {
   type SupportedRemoteCacheProviders,
   validateProjectName,
 } from '@rock-js/tools';
+import { stripTemplatePackageJsonMetadata } from './stripTemplatePackageJsonMetadata.js';
 import type { TemplateInfo } from './templates.js';
 import {
   BUNDLERS,
@@ -182,6 +183,9 @@ export async function run() {
   replacePlaceholder(absoluteTargetDir, normalizeProjectName(projectName));
   // For package.json name we can use any valid name (kebab-case, PascalCase, etc).
   rewritePackageJson(absoluteTargetDir, projectName);
+  // The template contains complete package metadata in package.json, required for OIDC publishing,
+  // but entirely undesired after expanding the template
+  stripTemplatePackageJsonMetadata(absoluteTargetDir);
   createConfig(
     absoluteTargetDir,
     platforms,

--- a/packages/create-app/src/lib/stripTemplatePackageJsonMetadata.ts
+++ b/packages/create-app/src/lib/stripTemplatePackageJsonMetadata.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const TEMPLATE_PACKAGE_JSON_KEYS_FOR_REMOVAL = [
+  'repository',
+  'homepage',
+  'bugs',
+  'license',
+  'author',
+] as const;
+
+/**
+ * Removes keys TEMPLATE_PACKAGE_JSON_KEYS_FOR_REMOVAL from package.json generated from rock-template-default.
+ * This helper is required because the metadata in template's package.json are required for OIDC publishing, but unwanted after expanding the template.
+ */
+export function stripTemplatePackageJsonMetadata(projectPath: string) {
+  const packageJsonPath = path.join(projectPath, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) {
+    return;
+  }
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+  for (const key of TEMPLATE_PACKAGE_JSON_KEYS_FOR_REMOVAL) {
+    delete packageJson[key];
+  }
+
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+}


### PR DESCRIPTION
This PR adds removal of metadata introduced to `rock-template-default`'s `package.json` for OIDC publishing in #705

These metadata are required for GH-NPM OIDC publishing to work, therefore must be kept in the repository, but stripped for the users.

Test plan: CI green - tests already check this & shall pass.