### PR TITLE
docs: clarify fingerprint env config

### DIFF
--- a/website/src/docs/configuration.md
+++ b/website/src/docs/configuration.md
@@ -717,7 +717,9 @@ The fingerprint configuration helps determine when builds should be cached and i
 
 - `extraSources`: when you have git submodules in your project
 - `ignorePaths`: custom directories that are not relevant for the native build state
-- `env`: environment variables that should affect the fingerprint
+- `env`: names of environment variables that should affect the fingerprint
+
+When you configure `env`, pass the environment variable names, not their resolved values. Rock reads each name from `process.env` when calculating the fingerprint.
 
 ```ts
 export default {
@@ -725,7 +727,7 @@ export default {
   fingerprint: {
     extraSources: ['./git-submodule'],
     ignorePaths: ['./temp'],
-    env: [process.env.CUSTOM_ENV],
+    env: ['CUSTOM_ENV'],
   },
 };
 ```


### PR DESCRIPTION
## Summary
Clarify the `fingerprint.env` configuration in the docs.
## Changes
- update the `env` description to state that it expects environment variable names
- add a short explanation that Rock resolves those names from `process.env` during fingerprint calculation
- fix the example from `env: [process.env.CUSTOM_ENV]` to `env: ['CUSTOM_ENV']`
## Why
The previous example suggested passing resolved env values, but the implementation expects a list of env variable names and reads them from `process.env` when building the fingerprint input.
## Verification
- checked `packages/config/src/lib/schema.ts` where `fingerprint.env` is defined as `string[]`
- checked `packages/tools/src/lib/fingerprint/index.ts` where each entry is used as a key into `process.env`