### PR TITLE
feat: add support for metro 0.84.x

### DIFF
--- a/.changeset/metro-084-support.md
+++ b/.changeset/metro-084-support.md
@@ -1,0 +1,5 @@
+---
+'@rock-js/plugin-metro': patch
+---
+
+Add support for Metro 0.84.x.

--- a/packages/plugin-metro/package.json
+++ b/packages/plugin-metro/package.json
@@ -21,10 +21,10 @@
   "dependencies": {
     "@react-native-community/cli-server-api": "^20.0.0",
     "@rock-js/tools": "^0.13.3",
-    "metro": "^0.83.3",
-    "metro-config": "^0.83.3",
-    "metro-core": "^0.83.3",
-    "metro-resolver": "^0.83.3",
+    "metro": "^0.83.3 || ^0.84.0",
+    "metro-config": "^0.83.3 || ^0.84.0",
+    "metro-core": "^0.83.3 || ^0.84.0",
+    "metro-resolver": "^0.83.3 || ^0.84.0",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,16 +407,16 @@ importers:
         specifier: ^0.13.3
         version: link:../tools
       metro:
-        specifier: ^0.83.3
+        specifier: ^0.83.3 || ^0.84.0
         version: 0.83.3
       metro-config:
-        specifier: ^0.83.3
+        specifier: ^0.83.3 || ^0.84.0
         version: 0.83.3
       metro-core:
-        specifier: ^0.83.3
+        specifier: ^0.83.3 || ^0.84.0
         version: 0.83.3
       metro-resolver:
-        specifier: ^0.83.3
+        specifier: ^0.83.3 || ^0.84.0
         version: 0.83.3
       tslib:
         specifier: ^2.3.0


### PR DESCRIPTION
### Summary
Broadens the accepted peer dependency range for `metro`, `metro-config`, `metro-core`, and `metro-resolver` from `^0.83.3` to `^0.83.3 || ^0.84.0` to support RN `0.85.3`, which requires metro `0.84.x`.