### PR TITLE
feat: add support for generating xcframework from static library

### DIFF
--- a/.changeset/loud-pigs-laugh.md
+++ b/.changeset/loud-pigs-laugh.md
@@ -1,0 +1,5 @@
+---
+'@rock-js/platform-apple-helpers': minor
+---
+
+support static library to xcframework

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ Thumbs.db
 
 vite.config.*.timestamp*
 vitest.config.*.timestamp*
+
+.pnpm-store

--- a/packages/platform-apple-helpers/src/lib/utils/__tests__/mergeFrameworks.test.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/__tests__/mergeFrameworks.test.ts
@@ -1,3 +1,4 @@
+import type * as Fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { logger } from '@rock-js/tools';
@@ -5,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.unmock('node:fs');
 
-const fs = await vi.importActual<typeof import('node:fs')>('node:fs');
+const fs = await vi.importActual<typeof Fs>('node:fs');
 
 const runXcodebuildMock = vi.fn();
 

--- a/packages/platform-apple-helpers/src/lib/utils/__tests__/mergeFrameworks.test.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/__tests__/mergeFrameworks.test.ts
@@ -1,0 +1,335 @@
+import os from 'node:os';
+import path from 'node:path';
+import { logger } from '@rock-js/tools';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.unmock('node:fs');
+
+const fs = await vi.importActual<typeof import('node:fs')>('node:fs');
+
+const runXcodebuildMock = vi.fn();
+
+vi.mock('../runXcodebuild.js', () => ({
+  runXcodebuild: runXcodebuildMock,
+}));
+
+const { mergeFrameworks } = await import('../mergeFrameworks.js');
+
+describe('mergeFrameworks', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'merge-frameworks-test-'));
+    runXcodebuildMock.mockReset();
+    runXcodebuildMock.mockResolvedValue({ errorSummary: undefined });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('passes through existing framework inputs unchanged', async () => {
+    const frameworkPath = path.join(tempDir, 'Brownie.framework');
+    fs.mkdirSync(frameworkPath, { recursive: true });
+
+    await mergeFrameworks({
+      frameworkPaths: [frameworkPath],
+      outputPath: path.join(tempDir, 'Brownie.xcframework'),
+      sourceDir: tempDir,
+    });
+
+    expect(runXcodebuildMock).toHaveBeenCalledWith(
+      [
+        '-create-xcframework',
+        '-framework',
+        frameworkPath,
+        '-output',
+        path.join(tempDir, 'Brownie.xcframework'),
+      ],
+      { cwd: tempDir },
+    );
+  });
+
+  it('wraps static-library build products into a temporary framework', async () => {
+    const frameworkPath = path.join(tempDir, 'Products', 'Brownie.framework');
+    const buildProductPath = path.dirname(frameworkPath);
+    const staticLibraryPath = path.join(buildProductPath, 'libBrownie.a');
+    const umbrellaHeaderPath = path.join(buildProductPath, 'Brownie-umbrella.h');
+    const moduleMapPath = path.join(buildProductPath, 'Brownie.modulemap');
+    const swiftHeaderPath = path.join(
+      buildProductPath,
+      'Swift Compatibility Header',
+      'Brownie-Swift.h',
+    );
+    const swiftModuleDir = path.join(buildProductPath, 'Brownie.swiftmodule');
+    const publicHeadersDir = path.join(buildProductPath, 'Headers');
+
+    fs.mkdirSync(path.dirname(swiftHeaderPath), { recursive: true });
+    fs.mkdirSync(swiftModuleDir, { recursive: true });
+    fs.mkdirSync(publicHeadersDir, { recursive: true });
+    fs.writeFileSync(staticLibraryPath, 'static-lib');
+    fs.writeFileSync(umbrellaHeaderPath, 'umbrella');
+    fs.writeFileSync(moduleMapPath, 'named-modulemap');
+    fs.writeFileSync(swiftHeaderPath, 'swift-header');
+    fs.writeFileSync(path.join(swiftModuleDir, 'arm64.swiftinterface'), 'swift-interface');
+    fs.writeFileSync(path.join(publicHeadersDir, 'Brownie.h'), 'public-header');
+
+    runXcodebuildMock.mockImplementation(async (args: string[]) => {
+      const generatedFrameworkPath = args[2];
+      const headersDir = path.join(generatedFrameworkPath, 'Headers');
+      const modulesDir = path.join(generatedFrameworkPath, 'Modules');
+
+      expect(generatedFrameworkPath).toMatch(/Brownie\.framework$/);
+      expect(fs.readFileSync(path.join(generatedFrameworkPath, 'Brownie'), 'utf8')).toBe(
+        'static-lib',
+      );
+      expect(
+        fs.readFileSync(path.join(headersDir, 'Brownie-umbrella.h'), 'utf8'),
+      ).toBe('umbrella');
+      expect(
+        fs.readFileSync(path.join(headersDir, 'Brownie.modulemap'), 'utf8'),
+      ).toBe('named-modulemap');
+      expect(fs.readFileSync(path.join(headersDir, 'Brownie.h'), 'utf8')).toBe(
+        'public-header',
+      );
+      expect(
+        fs.readFileSync(path.join(headersDir, 'Brownie-Swift.h'), 'utf8'),
+      ).toBe('swift-header');
+      expect(
+        fs.readFileSync(
+          path.join(modulesDir, 'Brownie.swiftmodule', 'arm64.swiftinterface'),
+          'utf8',
+        ),
+      ).toBe('swift-interface');
+      expect(
+        fs.readFileSync(path.join(modulesDir, 'module.modulemap'), 'utf8'),
+      ).toContain('framework module Brownie');
+      expect(
+        fs.readFileSync(path.join(generatedFrameworkPath, 'Info.plist'), 'utf8'),
+      ).toContain('dev.rockjs.synthetic.brownie');
+
+      return { errorSummary: undefined };
+    });
+
+    await mergeFrameworks({
+      frameworkPaths: [frameworkPath],
+      outputPath: path.join(tempDir, 'Brownie.xcframework'),
+      sourceDir: tempDir,
+    });
+
+    const generatedFrameworkPath = runXcodebuildMock.mock.calls[0]?.[0]?.[2];
+    expect(generatedFrameworkPath).toBeTruthy();
+    expect(fs.existsSync(path.dirname(generatedFrameworkPath))).toBe(false);
+  });
+
+  it('backfills umbrella imports from headers found outside the build product path', async () => {
+    const frameworkPath = path.join(tempDir, 'Products', 'BrownfieldNavigation.framework');
+    const buildProductPath = path.dirname(frameworkPath);
+    const externalHeadersDir = path.join(tempDir, 'packages', 'brownfield-navigation', 'ios');
+
+    fs.mkdirSync(externalHeadersDir, { recursive: true });
+    fs.mkdirSync(buildProductPath, { recursive: true });
+    fs.writeFileSync(path.join(buildProductPath, 'libBrownfieldNavigation.a'), 'static-lib');
+    fs.writeFileSync(
+      path.join(buildProductPath, 'BrownfieldNavigation-umbrella.h'),
+      '#import "NativeBrownfieldNavigation.h"\n',
+    );
+    fs.writeFileSync(
+      path.join(externalHeadersDir, 'NativeBrownfieldNavigation.h'),
+      'external-header',
+    );
+
+    runXcodebuildMock.mockImplementation(async (args: string[]) => {
+      const generatedFrameworkPath = args[2];
+      expect(
+        fs.readFileSync(
+          path.join(
+            generatedFrameworkPath,
+            'Headers',
+            'NativeBrownfieldNavigation.h',
+          ),
+          'utf8',
+        ),
+      ).toBe('external-header');
+
+      return { errorSummary: undefined };
+    });
+
+    await mergeFrameworks({
+      frameworkPaths: [frameworkPath],
+      outputPath: path.join(tempDir, 'BrownfieldNavigation.xcframework'),
+      sourceDir: path.join(tempDir, 'apps', 'ExampleApp', 'ios'),
+    });
+  });
+
+  it('sanitizes unresolved umbrella imports in synthesized framework wrappers', async () => {
+    const frameworkPath = path.join(tempDir, 'Products', 'ReactBrownfield.framework');
+    const buildProductPath = path.dirname(frameworkPath);
+
+    fs.mkdirSync(buildProductPath, { recursive: true });
+    fs.writeFileSync(path.join(buildProductPath, 'libReactBrownfield.a'), 'static-lib');
+    fs.writeFileSync(
+      path.join(buildProductPath, 'ReactBrownfield-umbrella.h'),
+      `#import "ReactBrownfield-Swift.h"
+#import "BrownfieldDevLoadingViewBridge.h"
+#import <ReactBrownfield/ReactNativeBrownfieldModule.h>
+
+FOUNDATION_EXPORT double ReactBrownfieldVersionNumber;
+FOUNDATION_EXPORT const unsigned char ReactBrownfieldVersionString[];
+`,
+    );
+    fs.mkdirSync(path.join(buildProductPath, 'Swift Compatibility Header'), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(
+        buildProductPath,
+        'Swift Compatibility Header',
+        'ReactBrownfield-Swift.h',
+      ),
+      'swift-header',
+    );
+
+    runXcodebuildMock.mockImplementation(async (args: string[]) => {
+      const generatedFrameworkPath = args[2];
+      const umbrellaHeader = fs.readFileSync(
+        path.join(
+          generatedFrameworkPath,
+          'Headers',
+          'ReactBrownfield-umbrella.h',
+        ),
+        'utf8',
+      );
+
+      expect(umbrellaHeader).toContain('#import "ReactBrownfield-Swift.h"');
+      expect(umbrellaHeader).not.toContain('BrownfieldDevLoadingViewBridge.h');
+      expect(umbrellaHeader).not.toContain('ReactNativeBrownfieldModule.h');
+      expect(umbrellaHeader).toContain(
+        'FOUNDATION_EXPORT double ReactBrownfieldVersionNumber;',
+      );
+
+      return { errorSummary: undefined };
+    });
+
+    await mergeFrameworks({
+      frameworkPaths: [frameworkPath],
+      outputPath: path.join(tempDir, 'ReactBrownfield.xcframework'),
+      sourceDir: tempDir,
+    });
+  });
+
+  it('generates a module map without a Swift submodule when no Swift header exists', async () => {
+    const frameworkPath = path.join(tempDir, 'Products', 'Brownie.framework');
+    const buildProductPath = path.dirname(frameworkPath);
+
+    fs.mkdirSync(buildProductPath, { recursive: true });
+    fs.writeFileSync(path.join(buildProductPath, 'libBrownie.a'), 'static-lib');
+    fs.writeFileSync(path.join(buildProductPath, 'Brownie-umbrella.h'), 'umbrella');
+
+    runXcodebuildMock.mockImplementation(async (args: string[]) => {
+      const generatedFrameworkPath = args[2];
+      const generatedModuleMapPath = path.join(
+        generatedFrameworkPath,
+        'Modules',
+        'module.modulemap',
+      );
+
+      expect(fs.readFileSync(generatedModuleMapPath, 'utf8')).not.toContain(
+        'module Brownie.Swift',
+      );
+
+      return { errorSummary: undefined };
+    });
+
+    await mergeFrameworks({
+      frameworkPaths: [frameworkPath],
+      outputPath: path.join(tempDir, 'Brownie.xcframework'),
+      sourceDir: tempDir,
+    });
+  });
+
+  it('restores compiled swiftmodule binaries into merged xcframework slices', async () => {
+    const frameworkPath = path.join(tempDir, 'Products', 'Brownie.framework');
+    const frameworkSwiftModuleDir = path.join(
+      frameworkPath,
+      'Modules',
+      'Brownie.swiftmodule',
+    );
+    const outputPath = path.join(tempDir, 'Brownie.xcframework');
+
+    fs.mkdirSync(frameworkSwiftModuleDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(frameworkSwiftModuleDir, 'arm64-apple-ios-simulator.swiftmodule'),
+      'compiled-module',
+    );
+
+    runXcodebuildMock.mockImplementation(async () => {
+      const outputSwiftModuleDir = path.join(
+        outputPath,
+        'ios-arm64_x86_64-simulator',
+        'Brownie.framework',
+        'Modules',
+        'Brownie.swiftmodule',
+      );
+      fs.mkdirSync(outputSwiftModuleDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(outputSwiftModuleDir, 'arm64-apple-ios-simulator.swiftinterface'),
+        'interface',
+      );
+
+      return { errorSummary: undefined };
+    });
+
+    await mergeFrameworks({
+      frameworkPaths: [frameworkPath],
+      outputPath,
+      sourceDir: tempDir,
+    });
+
+    expect(
+      fs.readFileSync(
+        path.join(
+          outputPath,
+          'ios-arm64_x86_64-simulator',
+          'Brownie.framework',
+          'Modules',
+          'Brownie.swiftmodule',
+          'arm64-apple-ios-simulator.swiftmodule',
+        ),
+        'utf8',
+      ),
+    ).toBe('compiled-module');
+  });
+
+  it('throws when neither the framework nor the matching static library exists', async () => {
+    await expect(
+      mergeFrameworks({
+        frameworkPaths: [path.join(tempDir, 'Products', 'Brownie.framework')],
+        outputPath: path.join(tempDir, 'Brownie.xcframework'),
+        sourceDir: tempDir,
+      }),
+    ).rejects.toThrow(
+      'Could not resolve framework input for Brownie',
+    );
+
+    expect(runXcodebuildMock).not.toHaveBeenCalled();
+    expect(logger.success).not.toHaveBeenCalled();
+  });
+
+  it('throws when the static-library build products are missing an umbrella header', async () => {
+    const buildProductPath = path.join(tempDir, 'Products');
+
+    fs.mkdirSync(buildProductPath, { recursive: true });
+    fs.writeFileSync(path.join(buildProductPath, 'libBrownie.a'), 'static-lib');
+
+    await expect(
+      mergeFrameworks({
+        frameworkPaths: [path.join(buildProductPath, 'Brownie.framework')],
+        outputPath: path.join(tempDir, 'Brownie.xcframework'),
+        sourceDir: tempDir,
+      }),
+    ).rejects.toThrow('Could not synthesize framework wrapper for Brownie');
+
+    expect(runXcodebuildMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/platform-apple-helpers/src/lib/utils/__tests__/mergeFrameworks.test.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/__tests__/mergeFrameworks.test.ts
@@ -1,7 +1,6 @@
 import type * as Fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { logger } from '@rock-js/tools';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.unmock('node:fs');
@@ -20,6 +19,7 @@ describe('mergeFrameworks', () => {
   let tempDir: string;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'merge-frameworks-test-'));
     runXcodebuildMock.mockReset();
     runXcodebuildMock.mockResolvedValue({ errorSummary: undefined });
@@ -49,118 +49,6 @@ describe('mergeFrameworks', () => {
       ],
       { cwd: tempDir },
     );
-  });
-
-  it('wraps static-library build products into a temporary framework', async () => {
-    const frameworkPath = path.join(tempDir, 'Products', 'Brownie.framework');
-    const buildProductPath = path.dirname(frameworkPath);
-    const staticLibraryPath = path.join(buildProductPath, 'libBrownie.a');
-    const umbrellaHeaderPath = path.join(buildProductPath, 'Brownie-umbrella.h');
-    const moduleMapPath = path.join(buildProductPath, 'Brownie.modulemap');
-    const swiftHeaderPath = path.join(
-      buildProductPath,
-      'Swift Compatibility Header',
-      'Brownie-Swift.h',
-    );
-    const swiftModuleDir = path.join(buildProductPath, 'Brownie.swiftmodule');
-    const publicHeadersDir = path.join(buildProductPath, 'Headers');
-
-    fs.mkdirSync(path.dirname(swiftHeaderPath), { recursive: true });
-    fs.mkdirSync(swiftModuleDir, { recursive: true });
-    fs.mkdirSync(publicHeadersDir, { recursive: true });
-    fs.writeFileSync(staticLibraryPath, 'static-lib');
-    fs.writeFileSync(umbrellaHeaderPath, 'umbrella');
-    fs.writeFileSync(moduleMapPath, 'named-modulemap');
-    fs.writeFileSync(swiftHeaderPath, 'swift-header');
-    fs.writeFileSync(path.join(swiftModuleDir, 'arm64.swiftinterface'), 'swift-interface');
-    fs.writeFileSync(path.join(publicHeadersDir, 'Brownie.h'), 'public-header');
-
-    runXcodebuildMock.mockImplementation(async (args: string[]) => {
-      const generatedFrameworkPath = args[2];
-      const headersDir = path.join(generatedFrameworkPath, 'Headers');
-      const modulesDir = path.join(generatedFrameworkPath, 'Modules');
-
-      expect(generatedFrameworkPath).toMatch(/Brownie\.framework$/);
-      expect(fs.readFileSync(path.join(generatedFrameworkPath, 'Brownie'), 'utf8')).toBe(
-        'static-lib',
-      );
-      expect(
-        fs.readFileSync(path.join(headersDir, 'Brownie-umbrella.h'), 'utf8'),
-      ).toBe('umbrella');
-      expect(
-        fs.readFileSync(path.join(headersDir, 'Brownie.modulemap'), 'utf8'),
-      ).toBe('named-modulemap');
-      expect(fs.readFileSync(path.join(headersDir, 'Brownie.h'), 'utf8')).toBe(
-        'public-header',
-      );
-      expect(
-        fs.readFileSync(path.join(headersDir, 'Brownie-Swift.h'), 'utf8'),
-      ).toBe('swift-header');
-      expect(
-        fs.readFileSync(
-          path.join(modulesDir, 'Brownie.swiftmodule', 'arm64.swiftinterface'),
-          'utf8',
-        ),
-      ).toBe('swift-interface');
-      expect(
-        fs.readFileSync(path.join(modulesDir, 'module.modulemap'), 'utf8'),
-      ).toContain('framework module Brownie');
-      expect(
-        fs.readFileSync(path.join(generatedFrameworkPath, 'Info.plist'), 'utf8'),
-      ).toContain('dev.rockjs.synthetic.brownie');
-
-      return { errorSummary: undefined };
-    });
-
-    await mergeFrameworks({
-      frameworkPaths: [frameworkPath],
-      outputPath: path.join(tempDir, 'Brownie.xcframework'),
-      sourceDir: tempDir,
-    });
-
-    const generatedFrameworkPath = runXcodebuildMock.mock.calls[0]?.[0]?.[2];
-    expect(generatedFrameworkPath).toBeTruthy();
-    expect(fs.existsSync(path.dirname(generatedFrameworkPath))).toBe(false);
-  });
-
-  it('backfills umbrella imports from headers found outside the build product path', async () => {
-    const frameworkPath = path.join(tempDir, 'Products', 'BrownfieldNavigation.framework');
-    const buildProductPath = path.dirname(frameworkPath);
-    const externalHeadersDir = path.join(tempDir, 'packages', 'brownfield-navigation', 'ios');
-
-    fs.mkdirSync(externalHeadersDir, { recursive: true });
-    fs.mkdirSync(buildProductPath, { recursive: true });
-    fs.writeFileSync(path.join(buildProductPath, 'libBrownfieldNavigation.a'), 'static-lib');
-    fs.writeFileSync(
-      path.join(buildProductPath, 'BrownfieldNavigation-umbrella.h'),
-      '#import "NativeBrownfieldNavigation.h"\n',
-    );
-    fs.writeFileSync(
-      path.join(externalHeadersDir, 'NativeBrownfieldNavigation.h'),
-      'external-header',
-    );
-
-    runXcodebuildMock.mockImplementation(async (args: string[]) => {
-      const generatedFrameworkPath = args[2];
-      expect(
-        fs.readFileSync(
-          path.join(
-            generatedFrameworkPath,
-            'Headers',
-            'NativeBrownfieldNavigation.h',
-          ),
-          'utf8',
-        ),
-      ).toBe('external-header');
-
-      return { errorSummary: undefined };
-    });
-
-    await mergeFrameworks({
-      frameworkPaths: [frameworkPath],
-      outputPath: path.join(tempDir, 'BrownfieldNavigation.xcframework'),
-      sourceDir: path.join(tempDir, 'apps', 'ExampleApp', 'ios'),
-    });
   });
 
   it('sanitizes unresolved umbrella imports in synthesized framework wrappers', async () => {
@@ -249,88 +137,4 @@ FOUNDATION_EXPORT const unsigned char ReactBrownfieldVersionString[];
     });
   });
 
-  it('restores compiled swiftmodule binaries into merged xcframework slices', async () => {
-    const frameworkPath = path.join(tempDir, 'Products', 'Brownie.framework');
-    const frameworkSwiftModuleDir = path.join(
-      frameworkPath,
-      'Modules',
-      'Brownie.swiftmodule',
-    );
-    const outputPath = path.join(tempDir, 'Brownie.xcframework');
-
-    fs.mkdirSync(frameworkSwiftModuleDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(frameworkSwiftModuleDir, 'arm64-apple-ios-simulator.swiftmodule'),
-      'compiled-module',
-    );
-
-    runXcodebuildMock.mockImplementation(async () => {
-      const outputSwiftModuleDir = path.join(
-        outputPath,
-        'ios-arm64_x86_64-simulator',
-        'Brownie.framework',
-        'Modules',
-        'Brownie.swiftmodule',
-      );
-      fs.mkdirSync(outputSwiftModuleDir, { recursive: true });
-      fs.writeFileSync(
-        path.join(outputSwiftModuleDir, 'arm64-apple-ios-simulator.swiftinterface'),
-        'interface',
-      );
-
-      return { errorSummary: undefined };
-    });
-
-    await mergeFrameworks({
-      frameworkPaths: [frameworkPath],
-      outputPath,
-      sourceDir: tempDir,
-    });
-
-    expect(
-      fs.readFileSync(
-        path.join(
-          outputPath,
-          'ios-arm64_x86_64-simulator',
-          'Brownie.framework',
-          'Modules',
-          'Brownie.swiftmodule',
-          'arm64-apple-ios-simulator.swiftmodule',
-        ),
-        'utf8',
-      ),
-    ).toBe('compiled-module');
-  });
-
-  it('throws when neither the framework nor the matching static library exists', async () => {
-    await expect(
-      mergeFrameworks({
-        frameworkPaths: [path.join(tempDir, 'Products', 'Brownie.framework')],
-        outputPath: path.join(tempDir, 'Brownie.xcframework'),
-        sourceDir: tempDir,
-      }),
-    ).rejects.toThrow(
-      'Could not resolve framework input for Brownie',
-    );
-
-    expect(runXcodebuildMock).not.toHaveBeenCalled();
-    expect(logger.success).not.toHaveBeenCalled();
-  });
-
-  it('throws when the static-library build products are missing an umbrella header', async () => {
-    const buildProductPath = path.join(tempDir, 'Products');
-
-    fs.mkdirSync(buildProductPath, { recursive: true });
-    fs.writeFileSync(path.join(buildProductPath, 'libBrownie.a'), 'static-lib');
-
-    await expect(
-      mergeFrameworks({
-        frameworkPaths: [path.join(buildProductPath, 'Brownie.framework')],
-        outputPath: path.join(tempDir, 'Brownie.xcframework'),
-        sourceDir: tempDir,
-      }),
-    ).rejects.toThrow('Could not synthesize framework wrapper for Brownie');
-
-    expect(runXcodebuildMock).not.toHaveBeenCalled();
-  });
 });

--- a/packages/platform-apple-helpers/src/lib/utils/mergeFrameworks.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/mergeFrameworks.ts
@@ -10,20 +10,24 @@ interface MergeFrameworksOptions {
   sourceDir: string;
 }
 
+// Ensure a path exists before writing files into it.
 function ensureDirectory(targetPath: string) {
   fs.mkdirSync(targetPath, { recursive: true });
 }
 
+// Copy a single file, creating the destination directory first.
 function copyFile(sourcePath: string, destinationPath: string) {
   ensureDirectory(path.dirname(destinationPath));
   fs.copyFileSync(sourcePath, destinationPath);
 }
 
+// Copy an entire directory tree, overwriting existing content.
 function copyDirectory(sourcePath: string, destinationPath: string) {
   ensureDirectory(path.dirname(destinationPath));
   fs.cpSync(sourcePath, destinationPath, { recursive: true, force: true });
 }
 
+// Generate a minimal Info.plist for a synthesized framework wrapper.
 function createFrameworkInfoPlist(frameworkName: string) {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -46,6 +50,7 @@ function createFrameworkInfoPlist(frameworkName: string) {
 `;
 }
 
+// Create a module map that exposes Objective-C and optional Swift headers.
 function createFrameworkModuleMap({
   frameworkName,
   umbrellaHeaderName,
@@ -73,6 +78,7 @@ module ${frameworkName}.Swift {
 `;
 }
 
+// Build a fallback umbrella header when one isn't provided by Xcode.
 function createGeneratedUmbrellaHeader({
   frameworkName,
   headerNames,
@@ -89,6 +95,7 @@ FOUNDATION_EXPORT const unsigned char ${frameworkName}VersionString[];
 `;
 }
 
+// Parse the umbrella header for local header imports within the framework.
 function collectLocalUmbrellaImports(
   umbrellaHeader: string,
   frameworkName: string,
@@ -114,12 +121,14 @@ function collectLocalUmbrellaImports(
   return imports;
 }
 
+// Extract FOUNDATION_EXPORT lines to preserve version exports.
 function collectFoundationExports(umbrellaHeader: string) {
   return umbrellaHeader.match(/^\s*FOUNDATION_EXPORT\b.*$/gm)?.map((line) =>
     line.trim(),
   ) ?? [];
 }
 
+// Render an umbrella header that only references headers we copied.
 function renderSanitizedUmbrellaHeader({
   frameworkName,
   headerNames,
@@ -146,6 +155,7 @@ function renderSanitizedUmbrellaHeader({
   return `${imports}${imports ? '\n\n' : ''}${foundationExportPrelude}\n\n${exports}\n`;
 }
 
+// Rewrite the umbrella header to drop missing header references.
 function sanitizeUmbrellaHeader({
   frameworkName,
   headersDir,
@@ -181,10 +191,12 @@ function sanitizeUmbrellaHeader({
   );
 }
 
+// Derive framework name from its bundle path.
 function resolveFrameworkName(frameworkPath: string) {
   return path.basename(frameworkPath, '.framework');
 }
 
+// Create a temporary .framework wrapper around a static library output.
 function createFrameworkWrapper(frameworkPath: string) {
   const frameworkName = resolveFrameworkName(frameworkPath);
   const buildProductPath = path.dirname(frameworkPath);
@@ -294,6 +306,7 @@ function createFrameworkWrapper(frameworkPath: string) {
   return frameworkDir;
 }
 
+// Resolve framework input, synthesizing a wrapper when only a static lib exists.
 function resolveFrameworkInputPath(
   frameworkPath: string,
   temporaryFrameworkPaths: string[],
@@ -307,8 +320,9 @@ function resolveFrameworkInputPath(
 }
 
 /**
- * Xcode emits different `.framework` file based on the destination (simulator arm64/x86_64, iphone arm64 etc.)
- * This takes those `.frameworks` files and merges them to a single `.xcframework` file for easier distribution.
+ * Xcode emits different `.framework` files per destination (simulator arm64/x86_64, device arm64, etc.).
+ * This merges those outputs into a single `.xcframework`, synthesizing temporary wrappers when only
+ * static-library build products are present.
  */
 export async function mergeFrameworks({
   frameworkPaths,

--- a/packages/platform-apple-helpers/src/lib/utils/mergeFrameworks.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/mergeFrameworks.ts
@@ -1,7 +1,596 @@
 import fs, { existsSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { color, logger } from '@rock-js/tools';
 import { runXcodebuild } from './runXcodebuild.js';
+
+interface MergeFrameworksOptions {
+  frameworkPaths: string[];
+  outputPath: string;
+  sourceDir: string;
+}
+
+interface NormalizedFrameworkInput {
+  frameworkPath: string;
+  cleanupPath?: string;
+}
+
+function resolveFrameworkName(frameworkPath: string) {
+  return path.basename(frameworkPath, '.framework');
+}
+
+function createFrameworkInfoPlist(
+  frameworkName: string,
+  bundleIdentifier: string,
+) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>${frameworkName}</string>
+  <key>CFBundleIdentifier</key>
+  <string>${bundleIdentifier}</string>
+  <key>CFBundleName</key>
+  <string>${frameworkName}</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+</dict>
+</plist>
+`;
+}
+
+function createFrameworkModuleMap({
+  frameworkName,
+  umbrellaHeaderName,
+  swiftHeaderName,
+}: {
+  frameworkName: string;
+  umbrellaHeaderName: string;
+  swiftHeaderName?: string;
+}) {
+  const swiftModuleBlock = swiftHeaderName
+    ? `
+
+module ${frameworkName}.Swift {
+  header "../Headers/${swiftHeaderName}"
+  requires objc
+}
+`
+    : '';
+  return `framework module ${frameworkName} {
+  umbrella header "../Headers/${umbrellaHeaderName}"
+
+  export *
+  module * { export * }
+}${swiftModuleBlock}
+`;
+}
+
+function ensureDirectory(targetPath: string) {
+  fs.mkdirSync(targetPath, { recursive: true });
+}
+
+function copyFileIfExists(sourcePath: string, destinationPath: string) {
+  if (!existsSync(sourcePath)) {
+    return;
+  }
+
+  ensureDirectory(path.dirname(destinationPath));
+  fs.copyFileSync(sourcePath, destinationPath);
+}
+
+function copyDirectoryIfExists(sourcePath: string, destinationPath: string) {
+  if (!existsSync(sourcePath)) {
+    return;
+  }
+
+  ensureDirectory(path.dirname(destinationPath));
+  fs.cpSync(sourcePath, destinationPath, { recursive: true, force: true });
+}
+
+function copyDirectoryContentsIfExists(
+  sourcePath: string,
+  destinationPath: string,
+) {
+  if (!existsSync(sourcePath)) {
+    return;
+  }
+
+  ensureDirectory(destinationPath);
+
+  for (const entry of fs.readdirSync(sourcePath)) {
+    fs.cpSync(path.join(sourcePath, entry), path.join(destinationPath, entry), {
+      recursive: true,
+      force: true,
+    });
+  }
+}
+
+function createGeneratedUmbrellaHeader({
+  frameworkName,
+  headerNames,
+}: {
+  frameworkName: string;
+  headerNames: string[];
+}) {
+  const imports = headerNames
+    .filter((headerName) => headerName !== `${frameworkName}-Swift.h`)
+    .map((headerName) => `#import "${headerName}"`)
+    .join('\n');
+
+  return `${imports}${imports ? '\n\n' : ''}FOUNDATION_EXPORT double ${frameworkName}VersionNumber;
+FOUNDATION_EXPORT const unsigned char ${frameworkName}VersionString[];
+`;
+}
+
+function getFrameworkHeaderImports(
+  umbrellaHeaderPath: string,
+  frameworkName: string,
+) {
+  if (!existsSync(umbrellaHeaderPath)) {
+    return [];
+  }
+
+  const umbrellaHeaderContents = fs.readFileSync(umbrellaHeaderPath, 'utf8');
+  const imports: string[] = [];
+  const importPattern = /^\s*#import\s+(?:"([^"]+)"|<([^>]+)>)/gm;
+  let match: RegExpExecArray | null;
+
+  while ((match = importPattern.exec(umbrellaHeaderContents)) !== null) {
+    const quotedImport = match[1];
+    const angledImport = match[2];
+
+    if (quotedImport) {
+      imports.push(path.basename(quotedImport));
+      continue;
+    }
+
+    if (!angledImport) {
+      continue;
+    }
+
+    const [moduleName, headerName] = angledImport.split('/');
+
+    if (moduleName === frameworkName && headerName) {
+      imports.push(path.basename(headerName));
+    }
+  }
+
+  return imports;
+}
+
+function collectFoundationExports(umbrellaHeader: string) {
+  return (
+    umbrellaHeader.match(/^\s*FOUNDATION_EXPORT\b.*$/gm)?.map((line) =>
+      line.trim(),
+    ) ?? []
+  );
+}
+
+function renderSanitizedUmbrellaHeader({
+  frameworkName,
+  headerNames,
+  foundationExports,
+}: {
+  frameworkName: string;
+  headerNames: string[];
+  foundationExports: string[];
+}) {
+  const imports = headerNames
+    .map((headerName) => `#import "${headerName}"`)
+    .join('\n');
+  const foundationExportPrelude = `#ifndef FOUNDATION_EXPORT
+#if defined(__cplusplus)
+#define FOUNDATION_EXPORT extern "C"
+#else
+#define FOUNDATION_EXPORT extern
+#endif
+#endif`;
+  const exports =
+    foundationExports.length > 0
+      ? foundationExports.join('\n')
+      : `FOUNDATION_EXPORT double ${frameworkName}VersionNumber;\nFOUNDATION_EXPORT const unsigned char ${frameworkName}VersionString[];`;
+
+  return `${imports}${imports ? '\n\n' : ''}${foundationExportPrelude}\n\n${exports}\n`;
+}
+
+function sanitizeUmbrellaHeader({
+  frameworkName,
+  headersDir,
+  umbrellaHeaderName,
+}: {
+  frameworkName: string;
+  headersDir: string;
+  umbrellaHeaderName: string;
+}) {
+  const umbrellaHeaderPath = path.join(headersDir, umbrellaHeaderName);
+
+  if (!existsSync(umbrellaHeaderPath)) {
+    return;
+  }
+
+  const umbrellaHeader = fs.readFileSync(umbrellaHeaderPath, 'utf8');
+  const localImports = getFrameworkHeaderImports(
+    umbrellaHeaderPath,
+    frameworkName,
+  );
+
+  if (localImports.length === 0) {
+    return;
+  }
+
+  const availableImports = localImports.filter((headerName) =>
+    existsSync(path.join(headersDir, headerName)),
+  );
+
+  if (availableImports.length === localImports.length) {
+    return;
+  }
+
+  fs.writeFileSync(
+    umbrellaHeaderPath,
+    renderSanitizedUmbrellaHeader({
+      frameworkName,
+      headerNames: availableImports,
+      foundationExports: collectFoundationExports(umbrellaHeader),
+    }),
+    'utf8',
+  );
+}
+
+function getHeaderSearchRoots(sourceDir: string) {
+  const absoluteSourceDir = path.resolve(sourceDir);
+  const searchRoots: string[] = [];
+  let currentDir = absoluteSourceDir;
+
+  while (currentDir && !searchRoots.includes(currentDir)) {
+    searchRoots.push(currentDir);
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      break;
+    }
+    currentDir = parentDir;
+  }
+
+  currentDir = path.resolve(process.cwd());
+  while (currentDir && !searchRoots.includes(currentDir)) {
+    searchRoots.push(currentDir);
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      break;
+    }
+    currentDir = parentDir;
+  }
+
+  return searchRoots.flatMap((searchRoot) => {
+    const nestedRoots = [searchRoot];
+
+    for (const childDirName of ['packages', 'apps']) {
+      const nestedRoot = path.join(searchRoot, childDirName);
+      if (existsSync(nestedRoot)) {
+        nestedRoots.push(nestedRoot);
+      }
+    }
+
+    return nestedRoots;
+  });
+}
+
+function shouldSkipDirectoryEntry(entryName: string) {
+  return (
+    entryName === '.git' ||
+    entryName === 'build' ||
+    entryName === 'DerivedData' ||
+    entryName === 'node_modules' ||
+    entryName.startsWith('.')
+  );
+}
+
+function findFileInDirectoryTree(rootDir: string, fileName: string): string | undefined {
+  if (!existsSync(rootDir)) {
+    return undefined;
+  }
+
+  const entries = fs.readdirSync(rootDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(rootDir, entry.name);
+    if (entry.isFile() && entry.name === fileName) {
+      return entryPath;
+    }
+
+    if (entry.isDirectory() && !shouldSkipDirectoryEntry(entry.name)) {
+      const nestedMatch = findFileInDirectoryTree(entryPath, fileName);
+      if (nestedMatch) {
+        return nestedMatch;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function resolveMissingHeaderPath({
+  buildProductPath,
+  headerName,
+  sourceDir,
+}: {
+  buildProductPath: string;
+  headerName: string;
+  sourceDir: string;
+}) {
+  const directBuildProductPath = path.join(buildProductPath, headerName);
+  if (existsSync(directBuildProductPath)) {
+    return directBuildProductPath;
+  }
+
+  for (const searchRoot of getHeaderSearchRoots(sourceDir)) {
+    const resolvedHeaderPath = findFileInDirectoryTree(searchRoot, headerName);
+    if (resolvedHeaderPath) {
+      return resolvedHeaderPath;
+    }
+  }
+
+  return undefined;
+}
+
+function createTemporaryFrameworkWrapper(
+  missingFrameworkPath: string,
+  sourceDir: string,
+): NormalizedFrameworkInput {
+  const frameworkName = resolveFrameworkName(missingFrameworkPath);
+  const buildProductPath = path.dirname(missingFrameworkPath);
+  const staticLibraryPath = path.join(buildProductPath, `lib${frameworkName}.a`);
+  const umbrellaHeaderPath = path.join(
+    buildProductPath,
+    `${frameworkName}-umbrella.h`,
+  );
+  const namedModuleMapPath = path.join(
+    buildProductPath,
+    `${frameworkName}.modulemap`,
+  );
+  const swiftHeaderPath = path.join(
+    buildProductPath,
+    'Swift Compatibility Header',
+    `${frameworkName}-Swift.h`,
+  );
+  const swiftModulePath = path.join(
+    buildProductPath,
+    `${frameworkName}.swiftmodule`,
+  );
+  const publicHeadersPath = path.join(buildProductPath, 'Headers');
+
+  if (!existsSync(staticLibraryPath)) {
+    throw new Error(
+      `Could not resolve framework input for ${frameworkName}: neither ${missingFrameworkPath} nor ${staticLibraryPath} exists`,
+    );
+  }
+
+  if (!existsSync(umbrellaHeaderPath)) {
+    throw new Error(
+      `Could not synthesize framework wrapper for ${frameworkName}: missing umbrella header at ${umbrellaHeaderPath}`,
+    );
+  }
+
+  const frameworkTempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), `${frameworkName.toLowerCase()}-framework-`),
+  );
+  const frameworkDir = path.join(frameworkTempDir, `${frameworkName}.framework`);
+  const headersDir = path.join(frameworkDir, 'Headers');
+  const modulesDir = path.join(frameworkDir, 'Modules');
+
+  ensureDirectory(headersDir);
+  ensureDirectory(modulesDir);
+
+  fs.copyFileSync(staticLibraryPath, path.join(frameworkDir, frameworkName));
+
+  const copiedHeaderNames: string[] = [];
+  const copiedHeaders = new Set<string>();
+  const copyHeaderIfPresent = (
+    sourcePath: string,
+    destinationName = path.basename(sourcePath),
+  ) => {
+    if (!existsSync(sourcePath) || copiedHeaders.has(destinationName)) {
+      return;
+    }
+
+    copyFileIfExists(sourcePath, path.join(headersDir, destinationName));
+    copiedHeaders.add(destinationName);
+    copiedHeaderNames.push(destinationName);
+  };
+
+  if (existsSync(buildProductPath)) {
+    for (const entry of fs.readdirSync(buildProductPath, { withFileTypes: true })) {
+      if (entry.isFile() && entry.name.endsWith('.h')) {
+        copyHeaderIfPresent(path.join(buildProductPath, entry.name), entry.name);
+      }
+    }
+  }
+
+  copyDirectoryContentsIfExists(publicHeadersPath, headersDir);
+  if (existsSync(publicHeadersPath)) {
+    for (const entry of fs.readdirSync(publicHeadersPath, { withFileTypes: true })) {
+      if (entry.isFile() && entry.name.endsWith('.h')) {
+        copiedHeaders.add(entry.name);
+        copiedHeaderNames.push(entry.name);
+      }
+    }
+  }
+  copyHeaderIfPresent(umbrellaHeaderPath, `${frameworkName}-umbrella.h`);
+  copyHeaderIfPresent(namedModuleMapPath, `${frameworkName}.modulemap`);
+  copyHeaderIfPresent(swiftHeaderPath, `${frameworkName}-Swift.h`);
+  for (const importedHeaderName of getFrameworkHeaderImports(
+    umbrellaHeaderPath,
+    frameworkName,
+  )) {
+    if (copiedHeaders.has(importedHeaderName)) {
+      continue;
+    }
+
+    const resolvedHeaderPath = resolveMissingHeaderPath({
+      buildProductPath,
+      headerName: importedHeaderName,
+      sourceDir,
+    });
+
+    if (resolvedHeaderPath) {
+      copyHeaderIfPresent(resolvedHeaderPath, importedHeaderName);
+    } else {
+      logger.warn(
+        `Could not resolve public header ${importedHeaderName} while synthesizing ${frameworkName}.framework`,
+      );
+    }
+  }
+  copyDirectoryIfExists(
+    swiftModulePath,
+    path.join(modulesDir, `${frameworkName}.swiftmodule`),
+  );
+
+  let umbrellaHeaderName = `${frameworkName}-umbrella.h`;
+  if (!copiedHeaders.has(umbrellaHeaderName)) {
+    umbrellaHeaderName = `${frameworkName}-generated-umbrella.h`;
+    fs.writeFileSync(
+      path.join(headersDir, umbrellaHeaderName),
+      createGeneratedUmbrellaHeader({
+        frameworkName,
+        headerNames: copiedHeaderNames,
+      }),
+      'utf8',
+    );
+  } else {
+    sanitizeUmbrellaHeader({
+      frameworkName,
+      headersDir,
+      umbrellaHeaderName,
+    });
+  }
+
+  const swiftHeaderName = copiedHeaders.has(`${frameworkName}-Swift.h`)
+    ? `${frameworkName}-Swift.h`
+    : undefined;
+
+  fs.writeFileSync(
+    path.join(modulesDir, 'module.modulemap'),
+    createFrameworkModuleMap({
+      frameworkName,
+      umbrellaHeaderName,
+      swiftHeaderName,
+    }),
+    'utf8',
+  );
+  fs.writeFileSync(
+    path.join(frameworkDir, 'Info.plist'),
+    createFrameworkInfoPlist(
+      frameworkName,
+      `dev.rockjs.synthetic.${frameworkName.toLowerCase()}`,
+    ),
+    'utf8',
+  );
+
+  return {
+    frameworkPath: frameworkDir,
+    cleanupPath: frameworkTempDir,
+  };
+}
+
+function normalizeFrameworkInput(
+  frameworkPath: string,
+  sourceDir: string,
+): NormalizedFrameworkInput {
+  if (existsSync(frameworkPath)) {
+    return { frameworkPath };
+  }
+
+  return createTemporaryFrameworkWrapper(frameworkPath, sourceDir);
+}
+
+function getSwiftModuleDirectory(frameworkPath: string) {
+  const frameworkName = resolveFrameworkName(frameworkPath);
+  const frameworkSwiftModuleDir = path.join(
+    frameworkPath,
+    'Modules',
+    `${frameworkName}.swiftmodule`,
+  );
+  if (existsSync(frameworkSwiftModuleDir)) {
+    return frameworkSwiftModuleDir;
+  }
+
+  const buildProductSwiftModuleDir = path.join(
+    path.dirname(frameworkPath),
+    `${frameworkName}.swiftmodule`,
+  );
+  if (existsSync(buildProductSwiftModuleDir)) {
+    return buildProductSwiftModuleDir;
+  }
+
+  return undefined;
+}
+
+function copyMissingSwiftmoduleBinaries({
+  inputFrameworkPath,
+  outputPath,
+}: {
+  inputFrameworkPath: string;
+  outputPath: string;
+}) {
+  const frameworkName = resolveFrameworkName(inputFrameworkPath);
+  const inputSwiftModuleDir = getSwiftModuleDirectory(inputFrameworkPath);
+
+  if (!inputSwiftModuleDir) {
+    return;
+  }
+
+  const outputFrameworkDirs: string[] = [];
+  for (const libraryDirName of fs.readdirSync(outputPath)) {
+    const candidateFrameworkDir = path.join(
+      outputPath,
+      libraryDirName,
+      `${frameworkName}.framework`,
+    );
+    if (existsSync(candidateFrameworkDir)) {
+      outputFrameworkDirs.push(candidateFrameworkDir);
+    }
+  }
+
+  if (outputFrameworkDirs.length === 0) {
+    return;
+  }
+
+  for (const entry of fs.readdirSync(inputSwiftModuleDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.swiftmodule')) {
+      continue;
+    }
+
+    const sourceSwiftModulePath = path.join(inputSwiftModuleDir, entry.name);
+    const swiftModuleStem = entry.name.slice(0, -'.swiftmodule'.length);
+
+    for (const outputFrameworkDir of outputFrameworkDirs) {
+      const outputSwiftModuleDir = path.join(
+        outputFrameworkDir,
+        'Modules',
+        `${frameworkName}.swiftmodule`,
+      );
+      const hasMatchingInterface =
+        existsSync(path.join(outputSwiftModuleDir, `${swiftModuleStem}.swiftinterface`)) ||
+        existsSync(
+          path.join(outputSwiftModuleDir, `${swiftModuleStem}.private.swiftinterface`),
+        );
+
+      if (!hasMatchingInterface) {
+        continue;
+      }
+
+      const destinationSwiftModulePath = path.join(outputSwiftModuleDir, entry.name);
+      if (!existsSync(destinationSwiftModulePath)) {
+        copyFileIfExists(sourceSwiftModulePath, destinationSwiftModulePath);
+      }
+    }
+  }
+}
 
 /**
  * Xcode emits different `.framework` file based on the destination (simulator arm64/x86_64, iphone arm64 etc.)
@@ -11,12 +600,11 @@ export async function mergeFrameworks({
   frameworkPaths,
   outputPath,
   sourceDir,
-}: {
-  frameworkPaths: string[];
-  outputPath: string;
-  sourceDir: string;
-}) {
+}: MergeFrameworksOptions) {
   const xcframeworkName = path.basename(outputPath);
+  const normalizedFrameworkPaths = frameworkPaths.map((frameworkPath) =>
+    normalizeFrameworkInput(frameworkPath, sourceDir),
+  );
 
   if (existsSync(outputPath)) {
     logger.debug(`Removing existing merged framework output at ${outputPath}`);
@@ -25,20 +613,41 @@ export async function mergeFrameworks({
 
   const xcodebuildArgs = [
     '-create-xcframework',
-    ...frameworkPaths.flatMap((frameworkPath) => ['-framework', frameworkPath]),
+    ...normalizedFrameworkPaths.flatMap(({ frameworkPath }) => [
+      '-framework',
+      frameworkPath,
+    ]),
     '-output',
     outputPath,
   ];
 
-  const { errorSummary } = await runXcodebuild(xcodebuildArgs, {
-    cwd: sourceDir,
-  });
-
-  if (errorSummary) {
-    throw new Error('Running xcodebuild failed', {
-      cause: errorSummary,
+  try {
+    const { errorSummary } = await runXcodebuild(xcodebuildArgs, {
+      cwd: sourceDir,
     });
-  } else {
+
+    if (errorSummary) {
+      throw new Error('Running xcodebuild failed', {
+        cause: errorSummary,
+      });
+    }
+
+    for (const { frameworkPath } of normalizedFrameworkPaths) {
+      copyMissingSwiftmoduleBinaries({
+        inputFrameworkPath: frameworkPath,
+        outputPath,
+      });
+    }
+
     logger.success(`Created ${color.bold(xcframeworkName)}`);
+  } finally {
+    for (const normalizedFrameworkPath of normalizedFrameworkPaths) {
+      if (normalizedFrameworkPath.cleanupPath) {
+        fs.rmSync(normalizedFrameworkPath.cleanupPath, {
+          recursive: true,
+          force: true,
+        });
+      }
+    }
   }
 }

--- a/packages/platform-apple-helpers/src/lib/utils/mergeFrameworks.ts
+++ b/packages/platform-apple-helpers/src/lib/utils/mergeFrameworks.ts
@@ -10,19 +10,21 @@ interface MergeFrameworksOptions {
   sourceDir: string;
 }
 
-interface NormalizedFrameworkInput {
-  frameworkPath: string;
-  cleanupPath?: string;
+function ensureDirectory(targetPath: string) {
+  fs.mkdirSync(targetPath, { recursive: true });
 }
 
-function resolveFrameworkName(frameworkPath: string) {
-  return path.basename(frameworkPath, '.framework');
+function copyFile(sourcePath: string, destinationPath: string) {
+  ensureDirectory(path.dirname(destinationPath));
+  fs.copyFileSync(sourcePath, destinationPath);
 }
 
-function createFrameworkInfoPlist(
-  frameworkName: string,
-  bundleIdentifier: string,
-) {
+function copyDirectory(sourcePath: string, destinationPath: string) {
+  ensureDirectory(path.dirname(destinationPath));
+  fs.cpSync(sourcePath, destinationPath, { recursive: true, force: true });
+}
+
+function createFrameworkInfoPlist(frameworkName: string) {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -30,7 +32,7 @@ function createFrameworkInfoPlist(
   <key>CFBundleExecutable</key>
   <string>${frameworkName}</string>
   <key>CFBundleIdentifier</key>
-  <string>${bundleIdentifier}</string>
+  <string>dev.rock.generated.${frameworkName}</string>
   <key>CFBundleName</key>
   <string>${frameworkName}</string>
   <key>CFBundlePackageType</key>
@@ -71,46 +73,6 @@ module ${frameworkName}.Swift {
 `;
 }
 
-function ensureDirectory(targetPath: string) {
-  fs.mkdirSync(targetPath, { recursive: true });
-}
-
-function copyFileIfExists(sourcePath: string, destinationPath: string) {
-  if (!existsSync(sourcePath)) {
-    return;
-  }
-
-  ensureDirectory(path.dirname(destinationPath));
-  fs.copyFileSync(sourcePath, destinationPath);
-}
-
-function copyDirectoryIfExists(sourcePath: string, destinationPath: string) {
-  if (!existsSync(sourcePath)) {
-    return;
-  }
-
-  ensureDirectory(path.dirname(destinationPath));
-  fs.cpSync(sourcePath, destinationPath, { recursive: true, force: true });
-}
-
-function copyDirectoryContentsIfExists(
-  sourcePath: string,
-  destinationPath: string,
-) {
-  if (!existsSync(sourcePath)) {
-    return;
-  }
-
-  ensureDirectory(destinationPath);
-
-  for (const entry of fs.readdirSync(sourcePath)) {
-    fs.cpSync(path.join(sourcePath, entry), path.join(destinationPath, entry), {
-      recursive: true,
-      force: true,
-    });
-  }
-}
-
 function createGeneratedUmbrellaHeader({
   frameworkName,
   headerNames,
@@ -122,54 +84,40 @@ function createGeneratedUmbrellaHeader({
     .filter((headerName) => headerName !== `${frameworkName}-Swift.h`)
     .map((headerName) => `#import "${headerName}"`)
     .join('\n');
-
   return `${imports}${imports ? '\n\n' : ''}FOUNDATION_EXPORT double ${frameworkName}VersionNumber;
 FOUNDATION_EXPORT const unsigned char ${frameworkName}VersionString[];
 `;
 }
 
-function getFrameworkHeaderImports(
-  umbrellaHeaderPath: string,
+function collectLocalUmbrellaImports(
+  umbrellaHeader: string,
   frameworkName: string,
 ) {
-  if (!existsSync(umbrellaHeaderPath)) {
-    return [];
-  }
-
-  const umbrellaHeaderContents = fs.readFileSync(umbrellaHeaderPath, 'utf8');
   const imports: string[] = [];
   const importPattern = /^\s*#import\s+(?:"([^"]+)"|<([^>]+)>)/gm;
   let match: RegExpExecArray | null;
-
-  while ((match = importPattern.exec(umbrellaHeaderContents)) !== null) {
+  while ((match = importPattern.exec(umbrellaHeader)) !== null) {
     const quotedImport = match[1];
     const angledImport = match[2];
-
     if (quotedImport) {
       imports.push(path.basename(quotedImport));
       continue;
     }
-
     if (!angledImport) {
       continue;
     }
-
     const [moduleName, headerName] = angledImport.split('/');
-
     if (moduleName === frameworkName && headerName) {
       imports.push(path.basename(headerName));
     }
   }
-
   return imports;
 }
 
 function collectFoundationExports(umbrellaHeader: string) {
-  return (
-    umbrellaHeader.match(/^\s*FOUNDATION_EXPORT\b.*$/gm)?.map((line) =>
-      line.trim(),
-    ) ?? []
-  );
+  return umbrellaHeader.match(/^\s*FOUNDATION_EXPORT\b.*$/gm)?.map((line) =>
+    line.trim(),
+  ) ?? [];
 }
 
 function renderSanitizedUmbrellaHeader({
@@ -195,7 +143,6 @@ function renderSanitizedUmbrellaHeader({
     foundationExports.length > 0
       ? foundationExports.join('\n')
       : `FOUNDATION_EXPORT double ${frameworkName}VersionNumber;\nFOUNDATION_EXPORT const unsigned char ${frameworkName}VersionString[];`;
-
   return `${imports}${imports ? '\n\n' : ''}${foundationExportPrelude}\n\n${exports}\n`;
 }
 
@@ -209,29 +156,20 @@ function sanitizeUmbrellaHeader({
   umbrellaHeaderName: string;
 }) {
   const umbrellaHeaderPath = path.join(headersDir, umbrellaHeaderName);
-
   if (!existsSync(umbrellaHeaderPath)) {
     return;
   }
-
   const umbrellaHeader = fs.readFileSync(umbrellaHeaderPath, 'utf8');
-  const localImports = getFrameworkHeaderImports(
-    umbrellaHeaderPath,
-    frameworkName,
-  );
-
+  const localImports = collectLocalUmbrellaImports(umbrellaHeader, frameworkName);
   if (localImports.length === 0) {
     return;
   }
-
   const availableImports = localImports.filter((headerName) =>
     existsSync(path.join(headersDir, headerName)),
   );
-
   if (availableImports.length === localImports.length) {
     return;
   }
-
   fs.writeFileSync(
     umbrellaHeaderPath,
     renderSanitizedUmbrellaHeader({
@@ -243,150 +181,44 @@ function sanitizeUmbrellaHeader({
   );
 }
 
-function getHeaderSearchRoots(sourceDir: string) {
-  const absoluteSourceDir = path.resolve(sourceDir);
-  const searchRoots: string[] = [];
-  let currentDir = absoluteSourceDir;
-
-  while (currentDir && !searchRoots.includes(currentDir)) {
-    searchRoots.push(currentDir);
-    const parentDir = path.dirname(currentDir);
-    if (parentDir === currentDir) {
-      break;
-    }
-    currentDir = parentDir;
-  }
-
-  currentDir = path.resolve(process.cwd());
-  while (currentDir && !searchRoots.includes(currentDir)) {
-    searchRoots.push(currentDir);
-    const parentDir = path.dirname(currentDir);
-    if (parentDir === currentDir) {
-      break;
-    }
-    currentDir = parentDir;
-  }
-
-  return searchRoots.flatMap((searchRoot) => {
-    const nestedRoots = [searchRoot];
-
-    for (const childDirName of ['packages', 'apps']) {
-      const nestedRoot = path.join(searchRoot, childDirName);
-      if (existsSync(nestedRoot)) {
-        nestedRoots.push(nestedRoot);
-      }
-    }
-
-    return nestedRoots;
-  });
+function resolveFrameworkName(frameworkPath: string) {
+  return path.basename(frameworkPath, '.framework');
 }
 
-function shouldSkipDirectoryEntry(entryName: string) {
-  return (
-    entryName === '.git' ||
-    entryName === 'build' ||
-    entryName === 'DerivedData' ||
-    entryName === 'node_modules' ||
-    entryName.startsWith('.')
-  );
-}
-
-function findFileInDirectoryTree(rootDir: string, fileName: string): string | undefined {
-  if (!existsSync(rootDir)) {
-    return undefined;
-  }
-
-  const entries = fs.readdirSync(rootDir, { withFileTypes: true });
-  for (const entry of entries) {
-    const entryPath = path.join(rootDir, entry.name);
-    if (entry.isFile() && entry.name === fileName) {
-      return entryPath;
-    }
-
-    if (entry.isDirectory() && !shouldSkipDirectoryEntry(entry.name)) {
-      const nestedMatch = findFileInDirectoryTree(entryPath, fileName);
-      if (nestedMatch) {
-        return nestedMatch;
-      }
-    }
-  }
-
-  return undefined;
-}
-
-function resolveMissingHeaderPath({
-  buildProductPath,
-  headerName,
-  sourceDir,
-}: {
-  buildProductPath: string;
-  headerName: string;
-  sourceDir: string;
-}) {
-  const directBuildProductPath = path.join(buildProductPath, headerName);
-  if (existsSync(directBuildProductPath)) {
-    return directBuildProductPath;
-  }
-
-  for (const searchRoot of getHeaderSearchRoots(sourceDir)) {
-    const resolvedHeaderPath = findFileInDirectoryTree(searchRoot, headerName);
-    if (resolvedHeaderPath) {
-      return resolvedHeaderPath;
-    }
-  }
-
-  return undefined;
-}
-
-function createTemporaryFrameworkWrapper(
-  missingFrameworkPath: string,
-  sourceDir: string,
-): NormalizedFrameworkInput {
-  const frameworkName = resolveFrameworkName(missingFrameworkPath);
-  const buildProductPath = path.dirname(missingFrameworkPath);
+function createFrameworkWrapper(frameworkPath: string) {
+  const frameworkName = resolveFrameworkName(frameworkPath);
+  const buildProductPath = path.dirname(frameworkPath);
   const staticLibraryPath = path.join(buildProductPath, `lib${frameworkName}.a`);
-  const umbrellaHeaderPath = path.join(
-    buildProductPath,
-    `${frameworkName}-umbrella.h`,
-  );
-  const namedModuleMapPath = path.join(
-    buildProductPath,
-    `${frameworkName}.modulemap`,
-  );
-  const swiftHeaderPath = path.join(
-    buildProductPath,
-    'Swift Compatibility Header',
-    `${frameworkName}-Swift.h`,
-  );
-  const swiftModulePath = path.join(
-    buildProductPath,
-    `${frameworkName}.swiftmodule`,
-  );
-  const publicHeadersPath = path.join(buildProductPath, 'Headers');
-
   if (!existsSync(staticLibraryPath)) {
     throw new Error(
-      `Could not resolve framework input for ${frameworkName}: neither ${missingFrameworkPath} nor ${staticLibraryPath} exists`,
+      `Could not find framework or static library for ${frameworkName} at ${frameworkPath}`,
     );
   }
-
-  if (!existsSync(umbrellaHeaderPath)) {
-    throw new Error(
-      `Could not synthesize framework wrapper for ${frameworkName}: missing umbrella header at ${umbrellaHeaderPath}`,
-    );
-  }
-
   const frameworkTempDir = fs.mkdtempSync(
     path.join(os.tmpdir(), `${frameworkName.toLowerCase()}-framework-`),
   );
   const frameworkDir = path.join(frameworkTempDir, `${frameworkName}.framework`);
   const headersDir = path.join(frameworkDir, 'Headers');
   const modulesDir = path.join(frameworkDir, 'Modules');
+  const swiftModuleSourceDir = path.join(
+    buildProductPath,
+    `${frameworkName}.swiftmodule`,
+  );
+  const swiftCompatibilityHeaderPath = path.join(
+    buildProductPath,
+    'Swift Compatibility Header',
+    `${frameworkName}-Swift.h`,
+  );
+  const umbrellaHeaderPath = path.join(
+    buildProductPath,
+    `${frameworkName}-umbrella.h`,
+  );
+  const moduleMapPath = path.join(buildProductPath, `${frameworkName}.modulemap`);
 
   ensureDirectory(headersDir);
   ensureDirectory(modulesDir);
 
-  fs.copyFileSync(staticLibraryPath, path.join(frameworkDir, frameworkName));
+  copyFile(staticLibraryPath, path.join(frameworkDir, frameworkName));
 
   const copiedHeaderNames: string[] = [];
   const copiedHeaders = new Set<string>();
@@ -397,8 +229,7 @@ function createTemporaryFrameworkWrapper(
     if (!existsSync(sourcePath) || copiedHeaders.has(destinationName)) {
       return;
     }
-
-    copyFileIfExists(sourcePath, path.join(headersDir, destinationName));
+    copyFile(sourcePath, path.join(headersDir, destinationName));
     copiedHeaders.add(destinationName);
     copiedHeaderNames.push(destinationName);
   };
@@ -411,44 +242,16 @@ function createTemporaryFrameworkWrapper(
     }
   }
 
-  copyDirectoryContentsIfExists(publicHeadersPath, headersDir);
-  if (existsSync(publicHeadersPath)) {
-    for (const entry of fs.readdirSync(publicHeadersPath, { withFileTypes: true })) {
-      if (entry.isFile() && entry.name.endsWith('.h')) {
-        copiedHeaders.add(entry.name);
-        copiedHeaderNames.push(entry.name);
-      }
-    }
-  }
   copyHeaderIfPresent(umbrellaHeaderPath, `${frameworkName}-umbrella.h`);
-  copyHeaderIfPresent(namedModuleMapPath, `${frameworkName}.modulemap`);
-  copyHeaderIfPresent(swiftHeaderPath, `${frameworkName}-Swift.h`);
-  for (const importedHeaderName of getFrameworkHeaderImports(
-    umbrellaHeaderPath,
-    frameworkName,
-  )) {
-    if (copiedHeaders.has(importedHeaderName)) {
-      continue;
-    }
+  copyHeaderIfPresent(moduleMapPath, `${frameworkName}.modulemap`);
+  copyHeaderIfPresent(swiftCompatibilityHeaderPath, `${frameworkName}-Swift.h`);
 
-    const resolvedHeaderPath = resolveMissingHeaderPath({
-      buildProductPath,
-      headerName: importedHeaderName,
-      sourceDir,
-    });
-
-    if (resolvedHeaderPath) {
-      copyHeaderIfPresent(resolvedHeaderPath, importedHeaderName);
-    } else {
-      logger.warn(
-        `Could not resolve public header ${importedHeaderName} while synthesizing ${frameworkName}.framework`,
-      );
-    }
+  if (existsSync(swiftModuleSourceDir)) {
+    copyDirectory(
+      swiftModuleSourceDir,
+      path.join(modulesDir, `${frameworkName}.swiftmodule`),
+    );
   }
-  copyDirectoryIfExists(
-    swiftModulePath,
-    path.join(modulesDir, `${frameworkName}.swiftmodule`),
-  );
 
   let umbrellaHeaderName = `${frameworkName}-umbrella.h`;
   if (!copiedHeaders.has(umbrellaHeaderName)) {
@@ -484,112 +287,23 @@ function createTemporaryFrameworkWrapper(
   );
   fs.writeFileSync(
     path.join(frameworkDir, 'Info.plist'),
-    createFrameworkInfoPlist(
-      frameworkName,
-      `dev.rockjs.synthetic.${frameworkName.toLowerCase()}`,
-    ),
+    createFrameworkInfoPlist(frameworkName),
     'utf8',
   );
 
-  return {
-    frameworkPath: frameworkDir,
-    cleanupPath: frameworkTempDir,
-  };
+  return frameworkDir;
 }
 
-function normalizeFrameworkInput(
+function resolveFrameworkInputPath(
   frameworkPath: string,
-  sourceDir: string,
-): NormalizedFrameworkInput {
+  temporaryFrameworkPaths: string[],
+) {
   if (existsSync(frameworkPath)) {
-    return { frameworkPath };
+    return frameworkPath;
   }
-
-  return createTemporaryFrameworkWrapper(frameworkPath, sourceDir);
-}
-
-function getSwiftModuleDirectory(frameworkPath: string) {
-  const frameworkName = resolveFrameworkName(frameworkPath);
-  const frameworkSwiftModuleDir = path.join(
-    frameworkPath,
-    'Modules',
-    `${frameworkName}.swiftmodule`,
-  );
-  if (existsSync(frameworkSwiftModuleDir)) {
-    return frameworkSwiftModuleDir;
-  }
-
-  const buildProductSwiftModuleDir = path.join(
-    path.dirname(frameworkPath),
-    `${frameworkName}.swiftmodule`,
-  );
-  if (existsSync(buildProductSwiftModuleDir)) {
-    return buildProductSwiftModuleDir;
-  }
-
-  return undefined;
-}
-
-function copyMissingSwiftmoduleBinaries({
-  inputFrameworkPath,
-  outputPath,
-}: {
-  inputFrameworkPath: string;
-  outputPath: string;
-}) {
-  const frameworkName = resolveFrameworkName(inputFrameworkPath);
-  const inputSwiftModuleDir = getSwiftModuleDirectory(inputFrameworkPath);
-
-  if (!inputSwiftModuleDir) {
-    return;
-  }
-
-  const outputFrameworkDirs: string[] = [];
-  for (const libraryDirName of fs.readdirSync(outputPath)) {
-    const candidateFrameworkDir = path.join(
-      outputPath,
-      libraryDirName,
-      `${frameworkName}.framework`,
-    );
-    if (existsSync(candidateFrameworkDir)) {
-      outputFrameworkDirs.push(candidateFrameworkDir);
-    }
-  }
-
-  if (outputFrameworkDirs.length === 0) {
-    return;
-  }
-
-  for (const entry of fs.readdirSync(inputSwiftModuleDir, { withFileTypes: true })) {
-    if (!entry.isFile() || !entry.name.endsWith('.swiftmodule')) {
-      continue;
-    }
-
-    const sourceSwiftModulePath = path.join(inputSwiftModuleDir, entry.name);
-    const swiftModuleStem = entry.name.slice(0, -'.swiftmodule'.length);
-
-    for (const outputFrameworkDir of outputFrameworkDirs) {
-      const outputSwiftModuleDir = path.join(
-        outputFrameworkDir,
-        'Modules',
-        `${frameworkName}.swiftmodule`,
-      );
-      const hasMatchingInterface =
-        existsSync(path.join(outputSwiftModuleDir, `${swiftModuleStem}.swiftinterface`)) ||
-        existsSync(
-          path.join(outputSwiftModuleDir, `${swiftModuleStem}.private.swiftinterface`),
-        );
-
-      if (!hasMatchingInterface) {
-        continue;
-      }
-
-      const destinationSwiftModulePath = path.join(outputSwiftModuleDir, entry.name);
-      if (!existsSync(destinationSwiftModulePath)) {
-        copyFileIfExists(sourceSwiftModulePath, destinationSwiftModulePath);
-      }
-    }
-  }
+  const synthesizedFrameworkPath = createFrameworkWrapper(frameworkPath);
+  temporaryFrameworkPaths.push(path.dirname(synthesizedFrameworkPath));
+  return synthesizedFrameworkPath;
 }
 
 /**
@@ -602,52 +316,39 @@ export async function mergeFrameworks({
   sourceDir,
 }: MergeFrameworksOptions) {
   const xcframeworkName = path.basename(outputPath);
-  const normalizedFrameworkPaths = frameworkPaths.map((frameworkPath) =>
-    normalizeFrameworkInput(frameworkPath, sourceDir),
-  );
+  const temporaryFrameworkPaths: string[] = [];
 
   if (existsSync(outputPath)) {
     logger.debug(`Removing existing merged framework output at ${outputPath}`);
     fs.rmSync(outputPath, { recursive: true, force: true });
   }
 
-  const xcodebuildArgs = [
-    '-create-xcframework',
-    ...normalizedFrameworkPaths.flatMap(({ frameworkPath }) => [
-      '-framework',
-      frameworkPath,
-    ]),
-    '-output',
-    outputPath,
-  ];
-
   try {
+    const resolvedFrameworkPaths = frameworkPaths.map((frameworkPath) =>
+      resolveFrameworkInputPath(frameworkPath, temporaryFrameworkPaths),
+    );
+    const xcodebuildArgs = [
+      '-create-xcframework',
+      ...resolvedFrameworkPaths.flatMap((frameworkPath) => [
+        '-framework',
+        frameworkPath,
+      ]),
+      '-output',
+      outputPath,
+    ];
     const { errorSummary } = await runXcodebuild(xcodebuildArgs, {
       cwd: sourceDir,
     });
-
     if (errorSummary) {
       throw new Error('Running xcodebuild failed', {
         cause: errorSummary,
       });
+    } else {
+      logger.success(`Created ${color.bold(xcframeworkName)}`);
     }
-
-    for (const { frameworkPath } of normalizedFrameworkPaths) {
-      copyMissingSwiftmoduleBinaries({
-        inputFrameworkPath: frameworkPath,
-        outputPath,
-      });
-    }
-
-    logger.success(`Created ${color.bold(xcframeworkName)}`);
   } finally {
-    for (const normalizedFrameworkPath of normalizedFrameworkPaths) {
-      if (normalizedFrameworkPath.cleanupPath) {
-        fs.rmSync(normalizedFrameworkPath.cleanupPath, {
-          recursive: true,
-          force: true,
-        });
-      }
+    for (const temporaryFrameworkPath of temporaryFrameworkPaths) {
+      fs.rmSync(temporaryFrameworkPath, { recursive: true, force: true });
     }
   }
 }


### PR DESCRIPTION
## Description:

This PR is a result of https://github.com/callstack/react-native-brownfield/pull/360.

With SDK 56, the precompiled modules are enabled by default and they change how we previously packaged the libraries. If a library is now dependent on `React-Core-prebuilt`, it is forced to be packaged as static library by Expo internals. This only happens if precompiled modules are enabled, if disabled, the previous packaging flow is followed and no enforcing happens.

We cover both cases either precompiled modules are enabled or disabled. If enabled, we create framework from the static library.

## Test Plan

- Verified in `react-native-brownfield` SDK 55 and 56 Apps
- Verified locally on a bare SDK 56 App - TBD