### PR TITLE
fix(plugin-metro): support Windows dynamic imports

### DIFF
--- a/.changeset/warm-windows-imports.md
+++ b/.changeset/warm-windows-imports.md
@@ -1,0 +1,5 @@
+---
+'@rock-js/plugin-metro': patch
+---
+
+Fix Metro dynamic imports from resolved absolute paths on Windows.

--- a/packages/plugin-metro/src/lib/getReactNativeDeps.ts
+++ b/packages/plugin-metro/src/lib/getReactNativeDeps.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
 import type devMiddleware from '@react-native/dev-middleware';
 
 export async function getDevMiddleware(
@@ -14,7 +15,7 @@ export async function getDevMiddleware(
     paths: [reactNativeCommunityCliPluginPath],
   });
 
-  return import(devMiddlewarePath);
+  return import(pathToFileURL(devMiddlewarePath).href);
 }
 
 export async function getReactNativeCommunityCliPlugin(
@@ -26,5 +27,5 @@ export async function getReactNativeCommunityCliPlugin(
     { paths: [reactNativePath] },
   );
 
-  return import(reactNativeCommunityCliPluginPath);
+  return import(pathToFileURL(reactNativeCommunityCliPluginPath).href);
 }

--- a/packages/plugin-metro/src/lib/start/loadMetroConfig.ts
+++ b/packages/plugin-metro/src/lib/start/loadMetroConfig.ts
@@ -7,6 +7,7 @@
 
 import { createRequire } from 'node:module';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { logger } from '@rock-js/tools';
 import type { ConfigT, InputConfigT, YargArguments } from 'metro-config';
 import { loadConfig, mergeConfig, resolveConfig } from 'metro-config';
@@ -90,7 +91,9 @@ export default async function loadMetroConfig(
   let RNMetroConfig = null;
   try {
     RNMetroConfig = await import(
-      require.resolve('@react-native/metro-config', { paths: [ctx.root] })
+      pathToFileURL(
+        require.resolve('@react-native/metro-config', { paths: [ctx.root] }),
+      ).href
     );
   } catch {
     throw new Error(


### PR DESCRIPTION
## Summary
- Convert resolved Metro dependency paths to file URLs before passing them to dynamic import
- Fix Windows absolute paths like C:\... being treated as unsupported ESM specifiers
- Add a patch changeset for @rock-js/plugin-metro

## Verification
- pnpm --filter @rock-js/plugin-metro... build
- pnpm exec prettier --check .changeset/warm-windows-imports.md packages/plugin-metro/src/lib/getReactNativeDeps.ts packages/plugin-metro/src/lib/start/loadMetroConfig.ts
- pnpm exec eslint packages/plugin-metro/src/lib/getReactNativeDeps.ts packages/plugin-metro/src/lib/start/loadMetroConfig.ts

Downstream validation: verified the equivalent patch in module-federation/core with the Metro Android host running on Windows: host, remote, and nested remote rendered successfully in the emulator.