### PR TITLE
feat: add remote cache status command

### DIFF
--- a/.changeset/calm-caches-report.md
+++ b/.changeset/calm-caches-report.md
@@ -1,0 +1,5 @@
+---
+'rock': minor
+---
+
+Add `remote-cache status` for checking whether the current native fingerprint has a matching GitHub Actions or S3 remote build artifact.

--- a/.changeset/calm-caches-report.md
+++ b/.changeset/calm-caches-report.md
@@ -1,5 +1,5 @@
 ---
-'rock': minor
+'rock': patch
 ---
 
 Add `remote-cache status` for checking whether the current native fingerprint has a matching GitHub Actions or S3 remote build artifact.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+Rock is a pnpm monorepo for a modular React Native CLI. Configuration creates a shared
+`PluginApi`; platform, bundler, and utility plugins register commands against it.
+
+## Repository map
+
+- `packages/cli` and `packages/config`: CLI bootstrap, config loading, and plugin contracts.
+- `packages/tools`: shared types, fingerprinting, cache contracts, logging, and process helpers.
+- `packages/platform-*`: platform commands; Apple platforms share `platform-apple-helpers`.
+- `packages/plugin-*` and `packages/provider-*`: optional integrations and remote-cache providers.
+- `packages/create-app`: project scaffolding and generated configuration.
+- `website/src/docs`: user-facing documentation.
+
+## Working rules
+
+- Use pnpm only; do not add npm or Yarn lockfiles.
+- This is ESM TypeScript: preserve `.js` suffixes in relative imports.
+- Follow package boundaries and export public APIs through each package's `src/index.ts`.
+- Keep shared behavior provider/platform-agnostic; specialize only at package boundaries.
+- Reuse contracts and helpers from `@rock-js/tools` instead of duplicating them.
+- Colocate Vitest tests under `src/**/__tests__` and follow existing package patterns.
+- Update CLI help and website docs when changing user-facing commands or configuration.
+- For 0.x releases, use patch Changesets unless adding support for a new React Native version.
+- Keep PRs focused, preserve unrelated worktree changes, and use Conventional Commit prefixes.
+
+## Validation
+
+Start with the affected package's Vitest config and `tsc -p <package>/tsconfig.lib.json --noEmit`.
+For cross-package changes, run focused lint/format checks, then `pnpm validate` and `pnpm build`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,30 +1,27 @@
 # AGENTS.md
 
-Rock is a pnpm monorepo for a modular React Native CLI. Configuration creates a shared
-`PluginApi`; platform, bundler, and utility plugins register commands against it.
+Rock is a modular React Native CLI. `packages/config` loads project configuration and
+creates the `PluginApi`; platform, bundler, and utility plugins register commands through it.
 
-## Repository map
+## Architecture
 
-- `packages/cli` and `packages/config`: CLI bootstrap, config loading, and plugin contracts.
-- `packages/tools`: shared types, fingerprinting, cache contracts, logging, and process helpers.
-- `packages/platform-*`: platform commands; Apple platforms share `platform-apple-helpers`.
-- `packages/plugin-*` and `packages/provider-*`: optional integrations and remote-cache providers.
-- `packages/create-app`: project scaffolding and generated configuration.
-- `website/src/docs`: user-facing documentation.
+- Platform logic is encapsulated in `packages/platform-*`; projects add platforms dynamically
+  through configuration. Core code must use `PluginApi`, not hard-code platform implementations.
+- Shared Apple implementation belongs in `packages/platform-apple-helpers`.
+- `packages/tools` owns cross-package contracts, fingerprinting, caching, logging, and process helpers.
+- Remote-cache implementations belong in `packages/provider-*` behind `RemoteBuildCache`.
+- Keep shared command behavior provider- and platform-agnostic; specialize at package boundaries.
+- User-facing configuration changes may require matching `packages/create-app` template updates.
+- User-facing command or configuration changes require corresponding `website/src/docs` updates.
 
-## Working rules
+## Release rules
 
-- Use pnpm only; do not add npm or Yarn lockfiles.
-- This is ESM TypeScript: preserve `.js` suffixes in relative imports.
-- Follow package boundaries and export public APIs through each package's `src/index.ts`.
-- Keep shared behavior provider/platform-agnostic; specialize only at package boundaries.
-- Reuse contracts and helpers from `@rock-js/tools` instead of duplicating them.
-- Colocate Vitest tests under `src/**/__tests__` and follow existing package patterns.
-- Update CLI help and website docs when changing user-facing commands or configuration.
-- For 0.x releases, use patch Changesets unless adding support for a new React Native version.
-- Keep PRs focused, preserve unrelated worktree changes, and use Conventional Commit prefixes.
+- For the current 0.x line, use a patch Changeset unless adding support for a new React Native version.
+- Changesets version `@rock-js/*`, `rock`, and `create-rock` together as a fixed group.
 
 ## Validation
 
-Start with the affected package's Vitest config and `tsc -p <package>/tsconfig.lib.json --noEmit`.
-For cross-package changes, run focused lint/format checks, then `pnpm validate` and `pnpm build`.
+- Test and typecheck the affected package first.
+- Run `pnpm build` for cross-package API or contract changes.
+- Use `pnpm validate` before finalizing broad changes.
+- Some tests fetch external resources; isolate network failures before treating them as regressions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,10 @@ creates the `PluginApi`; platform, bundler, and utility plugins register command
 - `packages/tools` owns cross-package contracts, fingerprinting, caching, logging, and process helpers.
 - Remote-cache implementations belong in `packages/provider-*` behind `RemoteBuildCache`.
 - Keep shared command behavior provider- and platform-agnostic; specialize at package boundaries.
+- `templates/rock-template-default` follows the Community CLI template but is not a verbatim mirror;
+  platform and bundler packages contribute additional template fragments.
+- `create-rock` migrates existing Community CLI projects; preserve drop-in behavior unless a
+  difference is intentional and documented.
 - User-facing configuration changes may require matching `packages/create-app` template updates.
 - User-facing command or configuration changes require corresponding `website/src/docs` updates.
 
@@ -24,4 +28,3 @@ creates the `PluginApi`; platform, bundler, and utility plugins register command
 - Test and typecheck the affected package first.
 - Run `pnpm build` for cross-package API or contract changes.
 - Use `pnpm validate` before finalizing broad changes.
-- Some tests fetch external resources; isolate network failures before treating them as regressions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,14 +9,15 @@ creates the `PluginApi`; platform, bundler, and utility plugins register command
   through configuration. Core code must use `PluginApi`, not hard-code platform implementations.
 - Shared Apple implementation belongs in `packages/platform-apple-helpers`.
 - `packages/tools` owns cross-package contracts, fingerprinting, caching, logging, and process helpers.
-- Remote-cache implementations belong in `packages/provider-*` behind `RemoteBuildCache`.
 - Keep shared command behavior provider- and platform-agnostic; specialize at package boundaries.
+- `plugin-metro`'s `start` and `bundle` commands are ports of React Native's community CLI plugin;
+  diff their upstream sources on every React Native upgrade, especially Metro handling.
+- Runtime packages remain compatible with older React Native and Metro APIs; the default template
+  instead tracks the latest available React Native. Do not infer runtime minimums from template deps.
 - `templates/rock-template-default` follows the Community CLI template but is not a verbatim mirror;
   platform and bundler packages contribute additional template fragments.
 - `create-rock` migrates existing Community CLI projects; preserve drop-in behavior unless a
   difference is intentional and documented.
-- User-facing configuration changes may require matching `packages/create-app` template updates.
-- User-facing command or configuration changes require corresponding `website/src/docs` updates.
 
 ## Release rules
 
@@ -27,4 +28,3 @@ creates the `PluginApi`; platform, bundler, and utility plugins register command
 
 - Test and typecheck the affected package first.
 - Run `pnpm build` for cross-package API or contract changes.
-- Use `pnpm validate` before finalizing broad changes.

--- a/packages/cli/src/lib/plugins/__tests__/remoteCache.test.ts
+++ b/packages/cli/src/lib/plugins/__tests__/remoteCache.test.ts
@@ -1,0 +1,181 @@
+import type {
+  FingerprintOptions,
+  RemoteArtifact,
+  RemoteBuildCache,
+} from '@rock-js/tools';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { remoteCache } from '../remoteCache.js';
+
+const fingerprint = '7af554b93cd696ca95308fdebe3a4484001bb7b4';
+const artifactName = `rock-android-Adhoc-${fingerprint}`;
+const fingerprintOptions: FingerprintOptions = {
+  extraSources: [],
+  ignorePaths: [],
+  env: [],
+};
+
+const formatArtifactName = vi.hoisted(() => vi.fn());
+
+vi.mock('@rock-js/tools', async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...(original as Record<string, unknown>),
+    formatArtifactName,
+  };
+});
+
+function createRemoteCacheProvider(artifacts: RemoteArtifact[], name = 'S3') {
+  const list = vi.fn().mockResolvedValue(artifacts);
+  const remoteBuildCache: RemoteBuildCache = {
+    name,
+    list,
+    download: vi.fn(),
+    delete: vi.fn(),
+    upload: vi.fn(),
+  };
+
+  return {
+    list,
+    remoteCacheProvider: () => remoteBuildCache,
+  };
+}
+
+beforeEach(() => {
+  formatArtifactName.mockResolvedValue(artifactName);
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('remote-cache status', () => {
+  describe.each(['GitHub', 'S3'])('%s provider', (providerName) => {
+    test('reports a cache hit as JSON', async () => {
+      const artifact = {
+        name: artifactName,
+        url: 'https://example.com/artifact.zip',
+      };
+      const { list, remoteCacheProvider } = createRemoteCacheProvider(
+        [artifact],
+        providerName,
+      );
+
+      await remoteCache({
+        action: 'status',
+        args: {
+          platform: 'android',
+          traits: ['Adhoc'],
+          json: true,
+        },
+        remoteCacheProvider,
+        projectRoot: '/project',
+        fingerprintOptions,
+      });
+
+      expect(list).toHaveBeenCalledWith({ artifactName, limit: 1 });
+      expect(console.log).toHaveBeenCalledWith(
+        JSON.stringify(
+          {
+            provider: providerName,
+            fingerprint,
+            artifactName,
+            hit: true,
+            artifact,
+          },
+          null,
+          2,
+        ),
+      );
+    });
+
+    test('reports a cache miss as JSON', async () => {
+      const { remoteCacheProvider } = createRemoteCacheProvider(
+        [],
+        providerName,
+      );
+
+      await remoteCache({
+        action: 'status',
+        args: {
+          platform: 'android',
+          traits: ['Adhoc'],
+          json: true,
+        },
+        remoteCacheProvider,
+        projectRoot: '/project',
+        fingerprintOptions,
+      });
+
+      expect(console.log).toHaveBeenCalledWith(
+        JSON.stringify(
+          {
+            provider: providerName,
+            fingerprint,
+            artifactName,
+            hit: false,
+            artifact: null,
+          },
+          null,
+          2,
+        ),
+      );
+    });
+  });
+
+  test('fails when no remote cache provider is configured', async () => {
+    await expect(
+      remoteCache({
+        action: 'status',
+        args: {
+          platform: 'android',
+          traits: ['Adhoc'],
+          json: true,
+        },
+        remoteCacheProvider: null,
+        projectRoot: '/project',
+        fingerprintOptions,
+      }),
+    ).rejects.toThrow(
+      'No remote cache provider configured. Set "remoteCacheProvider" in rock.config.mjs before checking cache status.',
+    );
+  });
+
+  test('propagates provider lookup failures', async () => {
+    const { list, remoteCacheProvider } = createRemoteCacheProvider([]);
+    list.mockRejectedValueOnce(new Error('S3 is unavailable'));
+
+    await expect(
+      remoteCache({
+        action: 'status',
+        args: {
+          platform: 'android',
+          traits: ['Adhoc'],
+          json: true,
+        },
+        remoteCacheProvider,
+        projectRoot: '/project',
+        fingerprintOptions,
+      }),
+    ).rejects.toThrow('S3 is unavailable');
+  });
+
+  test('requires platform and traits', async () => {
+    const { remoteCacheProvider } = createRemoteCacheProvider([]);
+
+    await expect(
+      remoteCache({
+        action: 'status',
+        args: {
+          name: artifactName,
+          json: true,
+        },
+        remoteCacheProvider,
+        projectRoot: '/project',
+        fingerprintOptions,
+      }),
+    ).rejects.toThrow(
+      'The "status" action requires "--platform" and "--traits".',
+    );
+  });
+});

--- a/packages/cli/src/lib/plugins/__tests__/remoteCache.test.ts
+++ b/packages/cli/src/lib/plugins/__tests__/remoteCache.test.ts
@@ -123,7 +123,7 @@ describe('remote-cache status', () => {
     });
   });
 
-  test('fails when no remote cache provider is configured', async () => {
+  test('returns when no remote cache provider is configured', async () => {
     await expect(
       remoteCache({
         action: 'status',
@@ -136,9 +136,7 @@ describe('remote-cache status', () => {
         projectRoot: '/project',
         fingerprintOptions,
       }),
-    ).rejects.toThrow(
-      'No remote cache provider configured. Set "remoteCacheProvider" in rock.config.mjs before checking cache status.',
-    );
+    ).resolves.toBeNull();
   });
 
   test('propagates provider lookup failures', async () => {

--- a/packages/cli/src/lib/plugins/remoteCache.ts
+++ b/packages/cli/src/lib/plugins/remoteCache.ts
@@ -64,11 +64,6 @@ export async function remoteCache({
 }) {
   const isJsonOutput = args.json;
   if (!remoteCacheProvider) {
-    if (action === 'status') {
-      throw new RockError(
-        'No remote cache provider configured. Set "remoteCacheProvider" in rock.config.mjs before checking cache status.',
-      );
-    }
     return null;
   }
   const remoteBuildCache = remoteCacheProvider();

--- a/packages/cli/src/lib/plugins/remoteCache.ts
+++ b/packages/cli/src/lib/plugins/remoteCache.ts
@@ -2,7 +2,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { PluginApi, PluginOutput } from '@rock-js/config';
-import type { FingerprintOptions, RemoteBuildCache } from '@rock-js/tools';
+import type {
+  FingerprintOptions,
+  RemoteArtifact,
+  RemoteBuildCache,
+} from '@rock-js/tools';
 import {
   color,
   colorLink,
@@ -37,7 +41,15 @@ type Flags = {
   adHoc?: boolean;
 };
 
-async function remoteCache({
+type RemoteCacheStatus = {
+  provider: string;
+  fingerprint: string;
+  artifactName: string;
+  hit: boolean;
+  artifact: RemoteArtifact | null;
+};
+
+export async function remoteCache({
   action,
   args,
   remoteCacheProvider,
@@ -52,6 +64,11 @@ async function remoteCache({
 }) {
   const isJsonOutput = args.json;
   if (!remoteCacheProvider) {
+    if (action === 'status') {
+      throw new RockError(
+        'No remote cache provider configured. Set "remoteCacheProvider" in rock.config.mjs before checking cache status.',
+      );
+    }
     return null;
   }
   const remoteBuildCache = remoteCacheProvider();
@@ -93,6 +110,30 @@ async function remoteCache({
 - url: ${colorLink(artifact.url)}`);
           });
         }
+      }
+      break;
+    }
+    case 'status': {
+      const artifact = (
+        await remoteBuildCache.list({ artifactName, limit: 1 })
+      )[0];
+      const artifactNamePrefix = `rock-${args.platform}-${args.traits?.join('-')}-`;
+      const status: RemoteCacheStatus = {
+        provider: remoteBuildCache.name,
+        fingerprint: artifactName.slice(artifactNamePrefix.length),
+        artifactName,
+        hit: artifact !== undefined,
+        artifact: artifact ?? null,
+      };
+
+      if (isJsonOutput) {
+        console.log(JSON.stringify(status, null, 2));
+      } else {
+        logger.log(`Remote cache status:
+- provider: ${color.bold(remoteBuildCache.name)}
+- fingerprint: ${color.bold(color.magenta(status.fingerprint))}
+- artifact: ${color.bold(color.blue(artifactName))}
+- status: ${status.hit ? color.green('hit') : color.yellow('miss')}`);
       }
       break;
     }
@@ -457,7 +498,12 @@ function validateArgs(args: Flags, action: string) {
   if (!action) {
     // @todo make Commander handle this
     throw new RockError(
-      'Action is required. Available actions: list, list-all, download, upload, delete',
+      'Action is required. Available actions: list, status, list-all, download, upload, delete, get-provider-name',
+    );
+  }
+  if (action === 'status' && (!args.platform || !args.traits)) {
+    throw new RockError(
+      'The "status" action requires "--platform" and "--traits".',
     );
   }
   if (action === 'list-all' || action === 'get-provider-name') {
@@ -503,7 +549,7 @@ export const remoteCachePlugin =
         {
           name: '[action]',
           description:
-            'Select action, e.g. list, list-all, download, upload, delete, get-provider-name',
+            'Select action, e.g. list, status, list-all, download, upload, delete, get-provider-name',
         },
       ],
       options: [

--- a/website/src/docs/cli/introduction.md
+++ b/website/src/docs/cli/introduction.md
@@ -466,8 +466,7 @@ npx rock remote-cache status --platform ios --traits device,AdHoc --json
 The JSON output includes the provider, fingerprint, artifact name, hit status,
 and matching artifact information when one exists. It supports both bundled
 remote cache providers: GitHub Actions and S3 (including S3-compatible
-storage). The command fails when no remote cache provider is configured or the
-provider lookup fails.
+storage). The command fails when the provider lookup fails.
 
 #### Ad-hoc distribution
 

--- a/website/src/docs/cli/introduction.md
+++ b/website/src/docs/cli/introduction.md
@@ -424,6 +424,7 @@ Available actions:
 | Action              | Description                                                                       |
 | :------------------ | :-------------------------------------------------------------------------------- |
 | `list`              | Lists the latest artifact matching the specified criteria                         |
+| `status`            | Reports whether the current fingerprint has a matching cached artifact            |
 | `list-all`          | Lists all artifacts (optionally filtered by platform and traits)                  |
 | `download`          | Downloads an artifact from remote cache to local cache                            |
 | `upload`            | Uploads a binary to remote cache. Accepts `--ad-hoc` flag for Ad-Hoc distribution |
@@ -454,6 +455,19 @@ or pass `--traits`, so you don't need to pass the fingerprint:
 ```shell
 npx rock remote-cache download --platform ios --traits simulator,Release
 ```
+
+To check whether the current fingerprint has a matching cached artifact without
+downloading it:
+
+```shell
+npx rock remote-cache status --platform ios --traits device,AdHoc --json
+```
+
+The JSON output includes the provider, fingerprint, artifact name, hit status,
+and matching artifact information when one exists. It supports both bundled
+remote cache providers: GitHub Actions and S3 (including S3-compatible
+storage). The command fails when no remote cache provider is configured or the
+provider lookup fails.
 
 #### Ad-hoc distribution
 


### PR DESCRIPTION
## Summary

Add `remote-cache status` to report whether the current native fingerprint has a matching remote artifact.

The command returns structured JSON for CI usage, supports GitHub Actions and S3 through the existing provider contract, and fails clearly for configuration or provider errors.

Add concise repository guidance for coding agents, including Rock's 0.x patch Changeset convention.

## Validation

- `pnpm build`
- CLI, GitHub provider, and S3 provider Vitest suites
- TypeScript, ESLint, Prettier, and diff checks
